### PR TITLE
Fixed missing assignment introduced in Issue #504.

### DIFF
--- a/asgs_main.sh
+++ b/asgs_main.sh
@@ -1379,7 +1379,7 @@ variables_init()
    RIVERSITE=${RIVERSITE:-"ftp.nssl.noaa.gov"}
    RIVERDIR=${RIVERDIR:-"/projects/ciflow/adcirc_info"}
    RIVERUSER=${RIVERUSER:-null}
-   RIVERDATAPROTOCOL${RIVERDATAPROTOCOL:-null}
+   RIVERDATAPROTOCOL=${RIVERDATAPROTOCOL:-null}
    ELEVSTATIONS=null
    VELSTATIONS=null
    METSTATIONS=null


### PR DESCRIPTION
Issue 512: A recent change adding the ability to affect some asgs_main.sh
variables using the interactive environment introduced an error in a shell
assignment that was missing the actual assignment operator (equal sign).

Resolves #512.