### PR TITLE
Audited placement of the use/capture of $? (exit code).

### DIFF
--- a/cloud/general/init-adcirc.sh
+++ b/cloud/general/init-adcirc.sh
@@ -403,8 +403,8 @@ cd $ADCIRCDIR        && \
 $ADCIRC_MAKE_CMD     && \
 $ADCSWAN_MAKE_CMD
 
-# catch failed exit status, for both interactive and initial asgs-brew.pl build
 EXIT=$?
+
 if [ $EXIT -gt 0 ]; then
   echo "build failed ($EXIT)"
   exit $EXIT

--- a/input/machines/hatteras/hatteras.adcprep.template.slurm
+++ b/input/machines/hatteras/hatteras.adcprep.template.slurm
@@ -47,11 +47,11 @@ module load mvapich2/2.0-acis
 #----------------------------------------------------------------------------
 cd %advisdir%/%enstorm%
 $CMD 2>&1
+ERROVALUE=$?
 # 
 #----------------------------------------------------------------------------
 #           C H E C K   S T A T U S   O F   R E S U L T S
 #----------------------------------------------------------------------------
-ERROVALUE=$?
 # FIXME: insert code to detect failures in adcprep that still allow it to 
 # finish with a normal exit code
 if [ $ERROVALUE == 0 ] ; then

--- a/input/machines/hatteras/hatteras.template.slurm
+++ b/input/machines/hatteras/hatteras.template.slurm
@@ -57,11 +57,11 @@ module load mvapich2/2.0-acis
 #----------------------------------------------------------------------------
 ERROMSG=""
 $CMD 
+ERROVALUE=$?  # capture exit status
 # 
 #----------------------------------------------------------------------------
 #           C H E C K   S T A T U S   O F   R E S U L T S
 #----------------------------------------------------------------------------
-ERROVALUE=$?  # capture exit status
 if [ $ERROVALUE = 0 ] ; then
    for file in adcirc.log %advisdir%/%enstorm%/%jobtype%.%enstorm%.out ; do
       if [ -e $file ]; then

--- a/output/cera_contour/cera_contour_multiprog.slurm
+++ b/output/cera_contour/cera_contour_multiprog.slurm
@@ -48,12 +48,12 @@ DATETIME=`date +'%Y-%h-%d-T%H:%M:%S'`
 CMD="srun -n 84 -l --multi-prog elev_shape.conf"
 echo "[${DATETIME}] INFO: Executing cera_contour with the command $CMD" 
 $CMD
+ERROVALUE=$?  # capture exit status
 # 
 #----------------------------------------------------------------------------
 #           C H E C K   S T A T U S   O F   R E S U L T S
 #----------------------------------------------------------------------------
 ERROMSG=""
-ERROVALUE=$?  # capture exit status
 #
 if [ $ERROVALUE == 0 ] ; then
    RUNSUFFIX="finish"

--- a/qscript.template
+++ b/qscript.template
@@ -73,13 +73,13 @@ echo "hpc.job.%jobtype%.joblog : %advisdir%/%scenario%/%jobtype%.out" >> run.pro
 CMD="%cmd%"
 echo "cycle $CYCLE: $SCENARIO: $THIS: %jobtype%.%scenario% job ${%JOBID%} starting in $SCENARIODIR with the following command: $CMD" 2>&1 | awk -v level=INFO -v this=$THIS -f $SCRIPTDIR/monitoring/timestamp.awk | tee --append $SCENARIOLOG | tee --append $CYCLELOG | tee --append $SYSLOG | tee --append %jobtype%.%scenario%.run.start
 $CMD
+ERROVALUE=$?  # capture exit status
 #
 #----------------------------------------------------------------------------
 #           C H E C K   S T A T U S   O F   R E S U L T S
 #----------------------------------------------------------------------------
 ERROMSG=""
 RUNSUFFIX="finish"
-ERROVALUE=$?  # capture exit status
 if [ $ERROVALUE == 0 ] ; then
    if [[ $JOBTYPE = adcirc || $JOBTYPE = adcswan || $JOBTYPE = padcirc || $JOBTYPE = padcswan ]]; then
       # look for numerical instability errors in the stdout/stderr files

--- a/qscript.template-test
+++ b/qscript.template-test
@@ -79,13 +79,13 @@ echo "hpc.job.%jobtype%.joblog : %advisdir%/%scenario%/%jobtype%.out" >> run.pro
 CMD="%cmd%"
 echo "cycle $CYCLE: $SCENARIO: $THIS: %jobtype%.%scenario% job ${%JOBID%} starting in $SCENARIODIR with the following command: $CMD" 2>&1 | awk -v level=INFO -v this=$THIS -f $SCRIPTDIR/monitoring/timestamp.awk | tee --append $SCENARIOLOG | tee --append $CYCLELOG | tee --append $SYSLOG | tee --append %jobtype%.%scenario%.run.start
 $CMD
+ERROVALUE=$?  # capture exit status
 #
 #----------------------------------------------------------------------------
 #           C H E C K   S T A T U S   O F   R E S U L T S
 #----------------------------------------------------------------------------
 ERROMSG=""
 RUNSUFFIX="finish"
-ERROVALUE=$?  # capture exit status
 if [ $ERROVALUE == 0 ] ; then
    if [[ $JOBTYPE = adcirc || $JOBTYPE = adcswan || $JOBTYPE = padcirc || $JOBTYPE = padcswan ]]; then
       # look for numerical instability errors in the stdout/stderr files


### PR DESCRIPTION
Issue 538: Changes ensure clarity or that $? is used/captured immediately
after the command of concern.

Resolves #538.