### PR TITLE
Fixed patches for v55release that were misplacing an 'endif'.

### DIFF
--- a/patches/ADCIRC/v55release-swan-gfortran-10/01-v55release-qbc.patch
+++ b/patches/ADCIRC/v55release-swan-gfortran-10/01-v55release-qbc.patch
@@ -101,6 +101,7 @@ index 50d4603..28bf127 100644
 +        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX512 
 +        FLIBS   := $(INCDIRS) -xCORE-AVX512 
 +     endif
++  endif
 +  ifeq ($(MACHINENAME),supermic) 
 +     FFLAGS1 := $(INCDIRS) -O3 -FI -assume byterecl -132 -xAVX -assume buffered_io
 +     CFLAGS  := $(INCDIRS) -O3 -DLINUX -xAVX
@@ -110,7 +111,6 @@ index 50d4603..28bf127 100644
 +        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX 
 +        FLIBS   := $(INCDIRS) -xAVX
 +     endif
-+  endif
 +  endif
    endif
    #

--- a/patches/ADCIRC/v55release-swan-gfortran/01-v55release-qbc.patch
+++ b/patches/ADCIRC/v55release-swan-gfortran/01-v55release-qbc.patch
@@ -101,6 +101,7 @@ index 50d4603..28bf127 100644
 +        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX512 
 +        FLIBS   := $(INCDIRS) -xCORE-AVX512 
 +     endif
++  endif
 +  ifeq ($(MACHINENAME),supermic) 
 +     FFLAGS1 := $(INCDIRS) -O3 -FI -assume byterecl -132 -xAVX -assume buffered_io
 +     CFLAGS  := $(INCDIRS) -O3 -DLINUX -xAVX
@@ -110,7 +111,6 @@ index 50d4603..28bf127 100644
 +        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX 
 +        FLIBS   := $(INCDIRS) -xAVX
 +     endif
-+  endif
 +  endif
    endif
    #

--- a/patches/ADCIRC/v55release/01-v55release-qbc.patch
+++ b/patches/ADCIRC/v55release/01-v55release-qbc.patch
@@ -101,6 +101,7 @@ index 50d4603..28bf127 100644
 +        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX512 
 +        FLIBS   := $(INCDIRS) -xCORE-AVX512 
 +     endif
++  endif
 +  ifeq ($(MACHINENAME),supermic) 
 +     FFLAGS1 := $(INCDIRS) -O3 -FI -assume byterecl -132 -xAVX -assume buffered_io
 +     CFLAGS  := $(INCDIRS) -O3 -DLINUX -xAVX
@@ -110,7 +111,6 @@ index 50d4603..28bf127 100644
 +        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX 
 +        FLIBS   := $(INCDIRS) -xAVX
 +     endif
-+  endif
 +  endif
    endif
    #


### PR DESCRIPTION
Issue 548: Manually fixed 3 patches for v55release, all the same;
they were misplacing an 'endif', and only caused issues when building
v55release-* on supermic due to being enclosed in the queenbeeC
section.

Resolves #548.