### PR TITLE
Localized "$THIS" where possible, inside of bash function.

### DIFF
--- a/archive/enstorm_pedir_removal.sh
+++ b/archive/enstorm_pedir_removal.sh
@@ -23,7 +23,8 @@
 # This script gets all the information it needs from the
 # run.properties file instead of using command line arguments.
 #----------------------------------------------------------------
-THIS=archive/enstorm_pedir_removal.sh
+THIS=$(basename -- $0)
+
 # this assumes this script is executed in the dirctory that is to be archived
 SCENARIODIR=$PWD
 SCRIPTDIR=`sed -n 's/[ ^]*$//;s/path.scriptdir\s*:\s*//p' run.properties`

--- a/archive/ncfs_archive.sh
+++ b/archive/ncfs_archive.sh
@@ -38,7 +38,7 @@ SSHKEY=${13}
 #
 STORMDIR=${ADVISDIR}/${ENSTORM}       # shorthand
 cd ${STORMDIR}
-THIS=ncfs_archive.sh
+THIS=$(basename -- $0)
 #
 # grab all config info
 . ${CONFIG} 

--- a/archive/queenbee_archive.sh
+++ b/archive/queenbee_archive.sh
@@ -38,7 +38,7 @@ SSHKEY=${13}
 #
 STORMDIR=${ADVISDIR}/${ENSTORM}       # shorthand
 cd ${STORMDIR}
-THIS=queenbee_archive.sh
+THIS=$(basename -- $0)
 #
 # grab all config info
 . ${CONFIG} 

--- a/asgs_main.sh
+++ b/asgs_main.sh
@@ -24,6 +24,8 @@
 # You should have received a copy of the GNU General Public License
 # along with the ASGS.  If not, see <http://www.gnu.org/licenses/>.
 #----------------------------------------------------------------
+THIS=$(basename -- $0) 
+
 #
 #####################################################################
 #                B E G I N   F U N C T I O N S
@@ -65,7 +67,7 @@ checkFileExistence()
 { FPATH=$1
   FTYPE=$2
   FNAME=$3
-  THIS="asgs_main.sh>checkFileExistence()"
+  local THIS="asgs_main.sh>checkFileExistence()"
   if [[ -z $FNAME ]]; then
      RMQMessage "EXIT" "$CURRENT_EVENT" "$THIS" "FAIL" "The $FTYPE was not specified in the configuration file. When it is specified, the ASGS will look for it in the path ${FPATH}."
      fatal "$THIS: The $FTYPE was not specified in the configuration file. When it is specified, the ASGS will look for it in the path ${FPATH}."
@@ -1501,8 +1503,7 @@ variables_init()
 writeProperties()
 {
    STORMDIR=$1
-   WASTHIS=$THIS
-   THIS="asgs_main->writeProperties()"
+   local THIS="asgs_main->writeProperties()"
    logMessage "$THIS: Writing properties associated with ASGS configuration to $1/run.properties."
    # this is the first set of properties that will be written; if there is
    # a stray file from a previous (interrupted) asgs execution, this function
@@ -1624,7 +1625,6 @@ writeProperties()
    echo "instance : $INSTANCENAME" >> $STORMDIR/run.properties
    echo "pseudostorm : $PSEUDOSTORM" >> $STORMDIR/run.properties
    echo "intendedAudience : $INTENDEDAUDIENCE" >> $STORMDIR/run.properties
-   THIS=$WASTHIS
    # convert to scenario.json
    $SCRIPTDIR/metadata.pl --jsonify --metadatafile $STORMDIR/run.properties
 }
@@ -1634,8 +1634,7 @@ writeProperties()
 writeScenarioProperties()
 {
    STORMDIR=$1
-   WASTHIS=$THIS
-   THIS="asgs_main->writeScenarioProperties()"
+   local THIS="asgs_main->writeScenarioProperties()"
    logMessage "$THIS: Writing properties associated with this scenario to $1/run.properties."
    echo "path.cycledir : $ADVISDIR" >> $STORMDIR/run.properties
    echo "path.scenariodir : $STORMDIR" >> $STORMDIR/run.properties
@@ -1647,7 +1646,6 @@ writeScenarioProperties()
    echo "asgs.path.stormdir : $STORMDIR" >> $STORMDIR/run.properties
    echo "path.advisdir : $ADVISDIR" >> $STORMDIR/run.properties
    echo "path.stormdir : $STORMDIR" >> $STORMDIR/run.properties
-   THIS=$WASTHIS
 }
 #
 # write properties to the run.properties file that are associated with
@@ -1655,8 +1653,7 @@ writeScenarioProperties()
 writeNAMProperties()
 {
    STORMDIR=$1
-   WASTHIS=$THIS
-   THIS="asgs_main->writeNAMProperties()"
+   local THIS="asgs_main->writeNAMProperties()"
    logMessage "$THIS: Writing properties associated with meterorological forcing with the NAM model to $1/run.properties."
    echo "forcing.metclass : synoptic" >> $STORMDIR/run.properties
    echo "forcing.stormname : NA" >> $STORMDIR/run.properties
@@ -1677,7 +1674,6 @@ writeNAMProperties()
    echo "config.forcing.nam.forecastlength : $FORECASTLENGTH" >> $STORMDIR/run.properties
    echo "config.forcing.nam.reprojection.ptfile : $PTFILE" >> $STORMDIR/run.properties
    echo "config.forcing.nam.local.altnamdir : $ALTNAMDIR" >> $STORMDIR/run.properties
-   THIS=$WASTHIS
 }
 #
 # write properties to the run.properties file that are associated with
@@ -1685,8 +1681,7 @@ writeNAMProperties()
 writeTropicalCycloneProperties()
 {
    STORMDIR=$1
-   WASTHIS=$THIS
-   THIS="asgs_main->writeTropicalCycloneProperties()"
+   local THIS="asgs_main->writeTropicalCycloneProperties()"
    logMessage "$THIS: Writing properties associated with meterorological forcing configuration with a parametric vortex model to $1/run.properties."
    echo "forcing.metclass : tropical" >> $STORMDIR/run.properties
    echo "forcing.stormname : $STORM" >> $STORMDIR/run.properties
@@ -1709,7 +1704,6 @@ writeTropicalCycloneProperties()
    # legacy properties
    echo "storm : $STORM" >> $STORMDIR/run.properties
    echo "stormnumber : $STORM" >> $STORMDIR/run.properties
-   THIS=$WASTHIS
 }
 #
 # write properties to the run.properties file that are associated with
@@ -1717,14 +1711,12 @@ writeTropicalCycloneProperties()
 writeTropicalCycloneForecastProperties()
 {
    STORMDIR=$1
-   WASTHIS=$THIS
-   THIS="asgs_main->writeTropicalCycloneForecastProperties()"
+   local THIS="asgs_main->writeTropicalCycloneForecastProperties()"
    logMessage "$THIS: Writing properties associated with a particular forecast using a parametric vortex model to $1/run.properties."
     # write the start and end dates of the forecast to the run.properties file
     if [[ -e $RUNDIR/forecast.properties ]]; then
       cat $RUNDIR/forecast.properties >> ${STORMDIR}/run.properties
     fi
-   THIS=$WASTHIS
 }
 #
 # write properties to the run.properties file that are associated with
@@ -1732,8 +1724,7 @@ writeTropicalCycloneForecastProperties()
 writeWaveCouplingProperties()
 {
    STORMDIR=$1
-   WASTHIS=$THIS
-   THIS="asgs_main->writeWaveCouplingProperties()"
+   local THIS="asgs_main->writeWaveCouplingProperties()"
    logMessage "$THIS: Writing properties associated with wave coupling to $1/run.properties."
    echo "path.swandir : $SWANDIR" >> $STORMDIR/run.properties
    echo "coupling.waves.swan.reinitializeswan : $REINITIALIZESWAN" >> $STORMDIR/run.properties
@@ -1741,7 +1732,6 @@ writeWaveCouplingProperties()
    echo "swan.swandt : $SWANDT" >> $STORMDIR/run.properties
    echo "swan.input.file.swantemplate : $SWANTEMPLATE" >> $STORMDIR/run.properties
    echo "swan.input.file.swaninit : swaninit.template" >> $STORMDIR/run.properties
-   THIS=$WASTHIS
 }
 #
 # write properties to the run.properties file that are associated with
@@ -1749,8 +1739,7 @@ writeWaveCouplingProperties()
 writeJobResourceRequestProperties()
 {
    STORMDIR=$1
-   WASTHIS=$THIS
-   THIS="asgs_main->writeJobResourceRequestProperties()"
+   local THIS="asgs_main->writeJobResourceRequestProperties()"
    logMessage "$THIS: Writing properties associated with compute job to $1/run.properties."
    # on queenbeeC, if a parallel job uses 48 or fewer cores, it
    # should be submitted to the single queue to avoid "low utilization" emails
@@ -1787,7 +1776,6 @@ writeJobResourceRequestProperties()
    echo "cpurequest : $CPUREQUEST" >> ${STORMDIR}/run.properties
    echo "ncpu : $NCPU" >> ${STORMDIR}/run.properties  # number of compute CPUs
    echo "numwriters : $NUMWRITERS" >> ${STORMDIR}/run.properties  # number of dedicated writer CPUs
-   THIS=$WASTHIS
 }
 #####################################################################
 #                 E N D  F U N C T I O N S
@@ -1796,7 +1784,6 @@ writeJobResourceRequestProperties()
 #####################################################################
 #               B E G I N     E X E C U T I O N
 #####################################################################
-THIS="asgs_main.sh"
 
 CURRENT_EVENT="STRT" # used for RMQ messages
 CURRENT_STATE="INIT" # used for RMQ messages
@@ -1859,7 +1846,6 @@ if [[ $HPCENVSHORT = "null" ]]; then
    set_hpc
 fi
 readConfig # now we have the instancename and can name the asgs log file after it
-THIS=asgs_main.sh
 # set the value of SYSLOG (in monitoring/logging.sh)
 source ${SCRIPTDIR}/monitoring/logging.sh
 setSyslogFileName
@@ -2135,7 +2121,6 @@ if [[ $HOTORCOLD = hotstart ]]; then
    fi
 fi
 #
-THIS="asgs_main.sh"
 if [[ -e ${RUNARCHIVEBASE}/${PREPPEDARCHIVE} ]]; then
    RMQMessage "INFO" "$CURRENT_EVENT" "$THIS" "$CURRENT_STATE" "Found archive of preprocessed input files ${RUNARCHIVEBASE}/${PREPPEDARCHIVE}."
    logMessage "$THIS: Found archive of preprocessed input files ${RUNARCHIVEBASE}/${PREPPEDARCHIVE}."
@@ -2158,7 +2143,6 @@ done
 checkFileExistence $OUTPUTDIR "email notification script" $NOTIFY_SCRIPT
 checkFileExistence ${SCRIPTDIR}/archive "data archival script" $ARCHIVE
 
-THIS="asgs_main.sh"
 #
 if [[ $PERIODICFLUX != null ]]; then
    logMessage "$THIS: checking for FLUXCALCULATOR script"
@@ -2171,7 +2155,6 @@ fi
 #if [[ $TROPICALCYCLONE != off ]]; then
 #   checkFileExistence ${PERL5LIB} "perl library to support downloading forecast/advisories from the National Hurricane Center website" Tiny.pm
 #fi
-THIS="asgs_main.sh"
 #
 # Check for any issues or inconsistencies in configuration parameters.
 if [[ `expr $NCPU + $NUMWRITERS` -gt $NCPUCAPACITY ]]; then

--- a/config/config_defaults.sh
+++ b/config/config_defaults.sh
@@ -28,7 +28,8 @@
 # (e.g., the scenario package counter variable $si) or
 # anything associated exclusively with the initialization of
 # asgs (e.g., HPCENV).  
-THIS="config/config_defaults.sh"
+THIS=$(basename -- $0)
+
    BACKGROUNDMET=on
    TIDEFAC=off
    TROPICALCYCLONE=off

--- a/config/forcing_defaults.sh
+++ b/config/forcing_defaults.sh
@@ -20,7 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with the ASGS.  If not, see <http://www.gnu.org/licenses/>.
 #----------------------------------------------------------------
-THIS=config/forcing_defaults.sh
+THIS=$(basename -- $0)
 allMessage "$THIS: Setting default parameters for forcing."
 #
 # time between picking up advisory and giving up  on additional scenarios

--- a/config/io_defaults.sh
+++ b/config/io_defaults.sh
@@ -20,7 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with the ASGS.  If not, see <http://www.gnu.org/licenses/>.
 #----------------------------------------------------------------
-THIS=config/io_defaults.sh
+THIS=$(basename -- $0)
 allMessage "$THIS: Setting default parameters for input/output."
 #
 # water surface elevation station output

--- a/config/mesh_defaults.sh
+++ b/config/mesh_defaults.sh
@@ -20,7 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with the ASGS.  If not, see <http://www.gnu.org/licenses/>.
 #----------------------------------------------------------------
-THIS=config/mesh_defaults.sh
+THIS=$(basename -- $0)
 allMessage "$THIS: Setting default values for the mesh ${MESH}."
 MESHURL=https://asgs-static-assets.sfo2.digitaloceanspaces.com/meshes
 NODALATTRIBUTESURL=https://asgs-static-assets.sfo2.digitaloceanspaces.com/nodal-attributes

--- a/config/operator_defaults.sh
+++ b/config/operator_defaults.sh
@@ -20,7 +20,7 @@
 # You should have received a copy of the GNU General Public License
 # along with the ASGS.  If not, see <http://www.gnu.org/licenses/>.
 #----------------------------------------------------------------
-THIS=config/operator_defaults.sh
+THIS=$(basename -- $0)
 allMessage "$THIS is deprecated and will be removed in the future. In the meantime, source'ing $HOME/.asgsh_profile if it is present."
 
 if [ -e $HOME/.asgsh_profile ]; then

--- a/output/accumulateMinMax.sh
+++ b/output/accumulateMinMax.sh
@@ -20,7 +20,7 @@
 # along with the ASGS.  If not, see <http://www.gnu.org/licenses/>.
 #-----------------------------------------------------------------------
 #
-THIS=output/accumulateMinMax.sh
+THIS=$(basename -- $0)
 # Count command line arguments; use them if provided or use 
 # run.properties if not.
 declare -A properties

--- a/output/cera_post.sh
+++ b/output/cera_post.sh
@@ -36,7 +36,7 @@ SSHKEY=${13}
 #
 STORMDIR=${ADVISDIR}/${ENSTORM}       # shorthand
 cd ${STORMDIR} 2>> ${SYSLOG}
-THIS=cera_post.sh
+THIS=$(basename -- $0)
 # get the forecast ensemble member number 
 ENMEMNUM=`grep "forecastEnsembleMemberNumber" ${STORMDIR}/run.properties | sed 's/forecastEnsembleMemberNumber.*://' | sed 's/^\s//'` 2>> ${SYSLOG}
 #

--- a/output/cpra_postproc/MEX/run_mex.sh
+++ b/output/cpra_postproc/MEX/run_mex.sh
@@ -5,7 +5,7 @@
 # the specified command.
 #--------------------------------------------------------------------------
 #
-THIS=output/cpra_postproc/MEX/run_mex.sh
+THIS=$(basename -- $0)
 # give usage statement and exit if there are no command line options 
 if [[ $# -lt 1 ]]; then
   echo "$THIS: Usage:"

--- a/output/cpra_postproc/createPPT.sh
+++ b/output/cpra_postproc/createPPT.sh
@@ -25,7 +25,7 @@
 # along with the ASGS.  If not, see <http://www.gnu.org/licenses/>.
 #
 #--------------------------------------------------------------------------
-THIS="output/cpra_postproc/createPPT.sh"
+THIS=$(basename -- $0)
 batchJOBTYPE=cpra.figuregen
 postJOBTYPE=cpra.post
 #

--- a/output/cpra_slide_deck_post.sh
+++ b/output/cpra_slide_deck_post.sh
@@ -36,7 +36,7 @@
 #                        S E T U P 
 #--------------------------------------------------------------------------
 umask 002
-THIS="output/cpra_slide_deck_post.sh"
+THIS=$(basename -- $0)
 batchJOBTYPE=cpra.figuregen
 postJOBTYPE=cpra.post
 # SCENARIODIR: path where this ensemble member is supposed to run 

--- a/output/createMaxCSV.sh
+++ b/output/createMaxCSV.sh
@@ -20,7 +20,7 @@
 # along with the ASGS.  If not, see <http://www.gnu.org/licenses/>.
 #-----------------------------------------------------------------------
 #
-THIS=output/createMaxCSV.sh
+THIS=$(basename -- $0)
 # Count command line arguments; use them if provided or use 
 # run.properties if not.
 declare -A properties

--- a/output/createOPeNDAPFileList.sh
+++ b/output/createOPeNDAPFileList.sh
@@ -21,7 +21,7 @@
 # along with the ASGS.  If not, see <http://www.gnu.org/licenses/>.
 #-----------------------------------------------------------------------
 #
-THIS=output/createOPeNDAPFileList.sh
+THIS=$(basename -- $0)
 # Count command line arguments; use them if provided or use
 # run.properties if not.
 declare -A properties

--- a/output/hsofs_renci_post.sh
+++ b/output/hsofs_renci_post.sh
@@ -38,7 +38,7 @@ SSHKEY=${13}
 #
 STORMDIR=${ADVISDIR}/${ENSTORM}       # shorthand
 cd ${STORMDIR} 2>> ${SYSLOG}
-THIS=hsofs_renci_post.sh
+THIS=$(basename -- $0)
 # get the forecast ensemble member number 
 ENMEMNUM=`grep "forecastEnsembleMemberNumber" ${STORMDIR}/run.properties | sed 's/forecastEnsembleMemberNumber.*://' | sed 's/^\s//'` 2>> ${SYSLOG}
 #

--- a/output/includeWind10m.sh
+++ b/output/includeWind10m.sh
@@ -21,7 +21,7 @@
 # along with the ASGS.  If not, see <http://www.gnu.org/licenses/>.
 #-----------------------------------------------------------------------
 #
-THIS=output/includeWind10m.sh
+THIS=$(basename -- $0)
 # Count command line arguments; use them if provided or use 
 # run.properties if not.
 declare -A properties
@@ -70,7 +70,6 @@ source ${SCRIPTDIR}/monitoring/logging.sh
 source ${SCRIPTDIR}/platforms.sh
 # dispatch environment (using the functions in platforms.sh)
 env_dispatch ${HPCENVSHORT}
-THIS=output/includeWind10m.sh
 allMessage "$SCENARIO: $THIS: Starting post processing."
 scenarioMessage "$THIS: SCENARIO=$SCENARIO ; SCENARIODIR=$SCENARIODIR"
 cd ${SCENARIODIR} 2>&1 > errmsg || warn "cycle $CYCLE: $SCENARIO: $THIS: Could not change directory to $SCENARIODIR: `cat $errmsg`"

--- a/output/make_max_csv.sh
+++ b/output/make_max_csv.sh
@@ -35,7 +35,7 @@ SYSLOG=${12}
 #
 STORMDIR=${ADVISDIR}/${ENSTORM}       # shorthand
 cd ${STORMDIR} 2>> ${SYSLOG}
-THIS=ncfs_post.sh
+THIS=$(basename -- $0)
 # get the forecast ensemble member number 
 ENMEMNUM=`grep "forecastEnsembleMemberNumber" ${STORMDIR}/run.properties | sed 's/forecastEnsembleMemberNumber.*://' | sed 's/^\s//'` 2>> ${SYSLOG}
 #

--- a/output/ncem_post.sh
+++ b/output/ncem_post.sh
@@ -42,7 +42,7 @@ SSHKEY=${13}
 #
 STORMDIR=${ADVISDIR}/${ENSTORM}       # shorthand
 cd ${STORMDIR} 2>> ${SYSLOG}
-THIS=ncfs_post.sh
+THIS=$(basename -- $0)
 # get the forecast ensemble member number 
 ENMEMNUM=`grep "forecastEnsembleMemberNumber" ${STORMDIR}/run.properties | sed 's/forecastEnsembleMemberNumber.*://' | sed 's/^\s//'` 2>> ${SYSLOG}
 #

--- a/output/ncfs_post.sh
+++ b/output/ncfs_post.sh
@@ -42,7 +42,7 @@ SSHKEY=${13}
 #
 STORMDIR=${ADVISDIR}/${ENSTORM}       # shorthand
 cd ${STORMDIR} 2>> ${SYSLOG}
-THIS=ncfs_post.sh
+THIS=$(basename -- $0)
 # get the forecast ensemble member number 
 ENMEMNUM=`grep "forecastEnsembleMemberNumber" ${STORMDIR}/run.properties | sed 's/forecastEnsembleMemberNumber.*://' | sed 's/^\s//'` 2>> ${SYSLOG}
 #

--- a/output/ncfs_post_min.sh
+++ b/output/ncfs_post_min.sh
@@ -45,7 +45,7 @@ SSHKEY=${13}
 #
 STORMDIR=${ADVISDIR}/${ENSTORM}       # shorthand
 cd ${STORMDIR} 2>> ${SYSLOG}
-THIS=ncfs_post.sh
+THIS=$(basename -- $0)
 # get the forecast ensemble member number 
 ENMEMNUM=`grep "forecastEnsembleMemberNumber" ${STORMDIR}/run.properties | sed 's/forecastEnsembleMemberNumber.*://' | sed 's/^\s//'` 2>> ${SYSLOG}
 #

--- a/output/opendap_post.sh
+++ b/output/opendap_post.sh
@@ -20,7 +20,7 @@
 # along with the ASGS.  If not, see <http://www.gnu.org/licenses/>.
 #------------------------------------------------------------------------
 #
-THIS="output/opendap_post.sh"
+THIS=$(basename -- $0)
 #
 declare -A properties
 SCENARIODIR=$PWD
@@ -37,7 +37,6 @@ SCRIPTDIR=`sed -n 's/[ ^]*$//;s/path.scriptdir\s*:\s*//p' $RUNPROPERTIES`
 source $SCRIPTDIR/properties.sh
 # load run.properties file into associative array
 loadProperties $RUNPROPERTIES
-THIS="output/opendap_post.sh"
 echo "Finished loading properties."
 CONFIG=${properties['config.file']}
 COLDSTARTDATE=${properties["adcirc.time.coldstartdate"]} # used for the hindcast path
@@ -97,7 +96,6 @@ case $SCENARIO in
    ;;
 esac
 env_dispatch $HPCENVSHORT # set up JOBENV with perlbrew for asgs-sendmail.pl etc
-THIS="output/opendap_post.sh"
 OPENDAPMAILSERVER=${properties["notification.opendap.email.opendapmailserver"]}
 declare -a LINKABLEHOSTS
 declare -a COPYABLEHOSTS
@@ -115,7 +113,7 @@ for server in ${SERVERS[*]}; do
    # opendap service  (from platforms.sh)
    writeTDSProperties $server
    # FIXME: enable Operator to override TDS parameter settings from platforms.sh
-   THIS="output/opendap_post.sh-->$server"
+   _THIS="output/opendap_post.sh-->$server"
    loadProperties $RUNPROPERTIES # reload to pick up properties written by writeTDSProperties
    LINKABLEHOSTS=${properties["post.opendap.${server}.linkablehosts"]}
    COPYABLEHOSTS=${properties["post.opendap.${server}.copyablehosts"]}
@@ -256,26 +254,26 @@ END
    #                P O S T   V I A   S C P
    #-------------------------------------------------------------------
    # jgf20160803: Changed if/then to case-switch to accommodate new "copy" method.
-   scenarioMessage "$SCENARIO: $THIS: Posting to $OPENDAPHOST using the '$OPENDAPPOSTMETHOD' method."
+   scenarioMessage "$SCENARIO: $_THIS: Posting to $OPENDAPHOST using the '$OPENDAPPOSTMETHOD' method."
    case $OPENDAPPOSTMETHOD in
    "scp")
-      scenarioMessage "$SCENARIO: $THIS: Transferring files to $OPENDAPDIR on $OPENDAPHOST."
+      scenarioMessage "$SCENARIO: $_THIS: Transferring files to $OPENDAPDIR on $OPENDAPHOST."
       retry=0
       mkdirRetryLimit=10 # FIXME: hardcoded for now
       while [[ $retry -lt $mkdirRetryLimit ]]; do
          ssh $OPENDAPHOST "mkdir -p $OPENDAPDIR" >> $SCENARIOLOG 2>&1
          if [[ $? != 0 ]]; then
-            warn "$SCENARIO: $THIS: Failed to create the directory $OPENDAPDIR on the remote machine ${OPENDAPHOST}."
+            warn "$SCENARIO: $_THIS: Failed to create the directory $OPENDAPDIR on the remote machine ${OPENDAPHOST}."
             threddsPostStatus=fail
          else
-            scenarioMessage "$SCENARIO: $THIS: Successfully created the directory $OPENDAPDIR on the remote machine ${OPENDAPHOST}."
+            scenarioMessage "$SCENARIO: $_THIS: Successfully created the directory $OPENDAPDIR on the remote machine ${OPENDAPHOST}."
             break
          fi
          retry=`expr $retry + 1`
          if [[ $retry -lt $mkdirRetryLimit ]]; then
-            scenarioMessage "$SCENARIO: $THIS: Trying again."
+            scenarioMessage "$SCENARIO: $_THIS: Trying again."
          else
-            scenarioMessage "$SCENARIO: $THIS: Maximum number of retries has been reached. Moving on to the next operation."
+            scenarioMessage "$SCENARIO: $_THIS: Maximum number of retries has been reached. Moving on to the next operation."
          fi
       done
       # add code to create write permissions on directories so that other
@@ -287,17 +285,17 @@ END
          while [[ $retry -lt $timeoutRetryLimit ]]; do
             ssh $OPENDAPHOST "chmod a+wx $partialPath" 2>> $SYSLOG
             if [[ $? != 0 ]]; then
-               warn "$SCENARIO: $THIS: Failed to change permissions on the directory $partialPath on the remote machine ${OPENDAPHOST}."
+               warn "$SCENARIO: $_THIS: Failed to change permissions on the directory $partialPath on the remote machine ${OPENDAPHOST}."
                threddsPostStatus=fail
             else
-               scenarioMessage "$SCENARIO: $THIS: Successfully changed permissions to a+wx on '$partialPath'."
+               scenarioMessage "$SCENARIO: $_THIS: Successfully changed permissions to a+wx on '$partialPath'."
                break
             fi
             retry=`expr $retry + 1`
             if [[ $retry -lt $timeoutRetryLimit ]]; then
-               scenarioMessage "$SCENARIO: $THIS: Trying again."
+               scenarioMessage "$SCENARIO: $_THIS: Trying again."
             else
-               scenarioMessage "$SCENARIO: $THIS: Maximum number of retries has been reached. Moving on to the next operation."
+               scenarioMessage "$SCENARIO: $_THIS: Maximum number of retries has been reached. Moving on to the next operation."
             fi
          done
          # cut off the end of the partial path and keep going until we get down
@@ -311,17 +309,17 @@ END
          while [[ $retry -lt $timeoutRetryLimit ]]; do
             ssh $OPENDAPHOST "ln -s $OPENDAPBASEDIR/$STORMNAMEPATH $OPENDAPBASEDIR/$ALTSTORMNAMEPATH" 2>> $SYSLOG
             if [[ $? != 0 ]]; then
-               warn "$SCENARIO: $THIS: Failed to create symbolic link for the storm name."
+               warn "$SCENARIO: $_THIS: Failed to create symbolic link for the storm name."
                threddsPostStatus=fail
             else
-               scenarioMessage "$SCENARIO: $THIS: Successfully created symbolic link to storm name."
+               scenarioMessage "$SCENARIO: $_THIS: Successfully created symbolic link to storm name."
                break
             fi
             retry=`expr $retry + 1`
             if [[ $retry -lt $timeoutRetryLimit ]]; then
-               scenarioMessage "$SCENARIO: $THIS: Trying again."
+               scenarioMessage "$SCENARIO: $_THIS: Trying again."
             else
-               scenarioMessage "$SCENARIO: $THIS: Maximum number of retries has been reached. Moving on to the next operation."
+               scenarioMessage "$SCENARIO: $_THIS: Maximum number of retries has been reached. Moving on to the next operation."
             fi
          done
       fi
@@ -334,7 +332,7 @@ END
          fi
          # send opendap posting notification email early if directed
          if [[ $file = "sendNotification" ]]; then
-            scenarioMessage "$SCENARIO: $THIS: Sending 'results available' email to the following addresses before the full set of results has been posted: $OPENDAPNOTIFY."
+            scenarioMessage "$SCENARIO: $_THIS: Sending 'results available' email to the following addresses before the full set of results has been posted: $OPENDAPNOTIFY."
             # use asgs sendmail if Operator has set it up
             if [[ $OPENDAPMAILSERVER = "aws" ]]; then
                scenarioMessage "perl $SCRIPTDIR/asgs-sendmail.pl --config ${HOME}/asgs-global.conf --subject '$subject' --to $OPENDAPNOTIFY < ${SCENARIODIR}/opendap_results_notify_${server}.txt 2>> ${SYSLOG} 2>&1"
@@ -347,22 +345,22 @@ END
             continue
          fi
          chmod +r $file 2>> $SCENARIOLOG
-         scenarioMessage "$SCENARIO: $THIS: Transferring $file to ${OPENDAPHOST}:${OPENDAPDIR}."
+         scenarioMessage "$SCENARIO: $_THIS: Transferring $file to ${OPENDAPHOST}:${OPENDAPDIR}."
          retry=0
          while [[ $retry -lt $timeoutRetryLimit ]]; do
             scp $file ${OPENDAPHOST}:${OPENDAPDIR} >> $SCENARIOLOG 2>&1
             if [[ $? != 0 ]]; then
                threddsPostStatus=fail
-               warn "$SCENARIO: $THIS: Failed to transfer the file $file to ${OPENDAPHOST}:${OPENDAPDIR}."
+               warn "$SCENARIO: $_THIS: Failed to transfer the file $file to ${OPENDAPHOST}:${OPENDAPDIR}."
             else
-               scenarioMessage "$SCENARIO: $THIS: Successfully transferred the file."
+               scenarioMessage "$SCENARIO: $_THIS: Successfully transferred the file."
                break
             fi
             retry=`expr $retry + 1`
             if [[ $retry -lt $timeoutRetryLimit ]]; then
-               scenarioMessage "$SCENARIO: $THIS: Trying again."
+               scenarioMessage "$SCENARIO: $_THIS: Trying again."
             else
-               scenarioMessage "$SCENARIO: $THIS: Maximum number of retries has been reached. Moving on to the next operation."
+               scenarioMessage "$SCENARIO: $_THIS: Maximum number of retries has been reached. Moving on to the next operation."
             fi
          done
          # give the file read permissions on the remote filesystem
@@ -372,16 +370,16 @@ END
             ssh $OPENDAPHOST "chmod +r $OPENDAPDIR/$fname"
             if [[ $? != 0 ]]; then
                threddsPostStatus=fail
-               warn "$SCENARIO: $THIS: Failed to give the file $fname read permissions in ${OPENDAPHOST}:${OPENDAPDIR}."
+               warn "$SCENARIO: $_THIS: Failed to give the file $fname read permissions in ${OPENDAPHOST}:${OPENDAPDIR}."
             else
-               scenarioMessage "$SCENARIO: $THIS: Successfully changed permissions to +r on $OPENDAPDIR/$fname."
+               scenarioMessage "$SCENARIO: $_THIS: Successfully changed permissions to +r on $OPENDAPDIR/$fname."
                break
             fi
             retry=`expr $retry + 1`
             if [[ $retry -lt $timeoutRetryLimit ]]; then
-               scenarioMessage "$SCENARIO: $THIS: Trying again."
+               scenarioMessage "$SCENARIO: $_THIS: Trying again."
             else
-               scenarioMessage "$SCENARIO: $THIS: Maximum number of retries has been reached. Moving on to the next operation."
+               scenarioMessage "$SCENARIO: $_THIS: Maximum number of retries has been reached. Moving on to the next operation."
             fi
          done
          fileIndex=`expr $fileIndex + 1` 2>> $SCENARIOLOG
@@ -395,10 +393,10 @@ END
       echo "post.opendap.${server}.rsyncsshoptions : $rsyncSSHOptions" >> run.properties 2>> $SYSLOG
       rsyncOptions="-z --copy-links"
       echo "post.opendap.${server}.rsyncoptions : $rsyncOptions" >> run.properties 2>> $SYSLOG
-      allMessage "$SCENARIO: $THIS: Transferring files to $OPENDAPDIR on $OPENDAPHOST."
+      allMessage "$SCENARIO: $_THIS: Transferring files to $OPENDAPDIR on $OPENDAPHOST."
       ssh $OPENDAPHOST "mkdir -p $OPENDAPDIR" >> $SCENARIOLOG 2>&1
       if [[ $? != 0 ]]; then
-         warn "$SCENARIO: $THIS: Failed to create the directory $OPENDAPDIR on the remote machine ${OPENDAPHOST}."
+         warn "$SCENARIO: $_THIS: Failed to create the directory $OPENDAPDIR on the remote machine ${OPENDAPHOST}."
          threddsPostStatus=fail
       fi
       # add code to create write permissions on directories so that other
@@ -409,17 +407,17 @@ END
          while [[ $retry -lt $timeoutRetryLimit ]]; do
             ssh $OPENDAPHOST "chmod a+wx $partialPath" 2>> $SYSLOG
             if [[ $? != 0 ]]; then
-               warn "$SCENARIO: $THIS: Failed to change permissions on the directory $partialPath on the remote machine ${OPENDAPHOST}."
+               warn "$SCENARIO: $_THIS: Failed to change permissions on the directory $partialPath on the remote machine ${OPENDAPHOST}."
                threddsPostStatus=fail
             else
-               scenarioMessage "$SCENARIO: $THIS: Successfully changed permissions."
+               scenarioMessage "$SCENARIO: $_THIS: Successfully changed permissions."
                break
             fi
             retry=`expr $retry + 1`
             if [[ $retry -lt $timeoutRetryLimit ]]; then
-                scenarioMessage "$SCENARIO: $THIS: Trying again."
+                scenarioMessage "$SCENARIO: $_THIS: Trying again."
             else
-               scenarioMessage "$SCENARIO: $THIS: Maximum number of retries has been reached. Moving on to the next operation."
+               scenarioMessage "$SCENARIO: $_THIS: Maximum number of retries has been reached. Moving on to the next operation."
             fi
          done
          # cut off the end of the partial path and keep going until we get down
@@ -432,7 +430,7 @@ END
          fi
          # send opendap posting notification email early if directed
          if [[ $file = "sendNotification" ]]; then
-            scenarioMessage "$SCENARIO: $THIS: Sending 'results available' email to the following addresses before the full set of results has been posted: $OPENDAPNOTIFY."
+            scenarioMessage "$SCENARIO: $_THIS: Sending 'results available' email to the following addresses before the full set of results has been posted: $OPENDAPNOTIFY."
             # use asgs sendmail if Operator has set it up
             if [[ $OPENDAPMAILSERVER = "aws" ]]; then
                $SCRIPTDIR/asgs-sendmail.pl --subject "$subject" --to "$OPENDAPNOTIFY" < ${SCENARIODIR}/opendap_results_notify_${server}.txt 2>> ${SYSLOG} 2>&1
@@ -443,11 +441,11 @@ END
             continue
          fi
          chmod +r $file 2>> $SYSLOG
-         scenarioMessage "$SCENARIO: $THIS: Transferring $file to ${OPENDAPHOST}:${OPENDAPDIR}."
+         scenarioMessage "$SCENARIO: $_THIS: Transferring $file to ${OPENDAPHOST}:${OPENDAPDIR}."
          rsync ${rsyncOptions} ${file} ${OPENDAPHOST}:${OPENDAPDIR} >> $SCENARIOLOG 2>&1
          if [[ $? != 0 ]]; then
             threddsPostStatus=fail
-            warn "$SCENARIO: $THIS: Failed to transfer the file $file to ${OPENDAPHOST}:${OPENDAPDIR}."
+            warn "$SCENARIO: $_THIS: Failed to transfer the file $file to ${OPENDAPHOST}:${OPENDAPDIR}."
          fi
       done
       ;;
@@ -477,17 +475,17 @@ END
          while [[ $retry -lt $timeoutRetryLimit ]]; do
             chmod a+wx $partialPath 2>> $SYSLOG
             if [[ $? != 0 ]]; then
-               warn "$SCENARIO: $THIS: Failed to change permissions on the directory ${partialPath}."
+               warn "$SCENARIO: $_THIS: Failed to change permissions on the directory ${partialPath}."
                threddsPostStatus=fail
             else
-               scenarioMessage "$SCENARIO: $THIS: Successfully changed permissions."
+               scenarioMessage "$SCENARIO: $_THIS: Successfully changed permissions."
                break
             fi
             retry=`expr $retry + 1`
             if [[ $retry -lt $timeoutRetryLimit ]]; then
-               scenarioMessage "$SCENARIO: $THIS: Trying again."
+               scenarioMessage "$SCENARIO: $_THIS: Trying again."
             else
-               scenarioMessage "$SCENARIO: $THIS: Maximum number of retries has been reached. Moving on to the next operation."
+               scenarioMessage "$SCENARIO: $_THIS: Maximum number of retries has been reached. Moving on to the next operation."
             fi
          done
          # cut off the end of the partial path and keep going until we get down
@@ -505,7 +503,7 @@ END
          fi
          # send opendap posting notification email early if directed
          if [[ $file = "sendNotification" ]]; then
-            scenarioMessage "$SCENARIO: $THIS: Sending 'results available' email to the following addresses before the full set of results has been posted: $OPENDAPNOTIFY."
+            scenarioMessage "$SCENARIO: $_THIS: Sending 'results available' email to the following addresses before the full set of results has been posted: $OPENDAPNOTIFY."
             # use asgs sendmail if Operator has set it up
             if [[ $OPENDAPMAILSERVER = "aws" ]]; then
                $SCRIPTDIR/asgs-sendmail.pl --subject "$subject" --to "$OPENDAPNOTIFY" < ${SCENARIODIR}/opendap_results_notify_${server}.txt 2>> ${SYSLOG} 2>&1
@@ -516,17 +514,17 @@ END
             continue
          fi
          chmod +r $file 2>> $SYSLOG
-         logMessage "$SCENARIO: $THIS: $postDesc $file."
+         logMessage "$SCENARIO: $_THIS: $postDesc $file."
          $postCMD $file $OPENDAPDIR 2>> ${SYSLOG}
          if [[ $? != 0 ]]; then
             threddsPostStatus=fail
-            warn "$SCENARIO: $THIS: $postDesc $file to ${OPENDAPDIR} failed."
+            warn "$SCENARIO: $_THIS: $postDesc $file to ${OPENDAPDIR} failed."
          fi
       done
       ;;
    *)
       threddsPostStatus=fail
-      warn "$SCENARIO: $THIS: The opendap post method $OPENDAPPOSTMETHOD was not recognized."
+      warn "$SCENARIO: $_THIS: The opendap post method $OPENDAPPOSTMETHOD was not recognized."
       ;;
    esac
    #
@@ -541,7 +539,7 @@ END
    #   cat ${SCENARIODIR}/opendap_results_notify.txt | mail  -S "replyto=$ASGSADMIN" -s "$subject" $ASGSADMIN 2>> ${SYSLOG} 2>&1
    #else
    if [[ $opendapEmailSent = "no" ]]; then
-      scenarioMessage "$SCENARIO: $THIS: Sending 'results available' email to the following addresses: $OPENDAPNOTIFY."
+      scenarioMessage "$SCENARIO: $_THIS: Sending 'results available' email to the following addresses: $OPENDAPNOTIFY."
       # use asgs sendmail if Operator has set it up
       if [[ $OPENDAPMAILSERVER = "aws" ]]; then
          $SCRIPTDIR/asgs-sendmail.pl --subject "$subject" --to "$OPENDAPNOTIFY" < ${SCENARIODIR}/opendap_results_notify_${server}.txt 2>> ${SYSLOG} 2>&1

--- a/output/pod_post.sh
+++ b/output/pod_post.sh
@@ -44,7 +44,7 @@ SSHKEY=${13}
 #
 STORMDIR=${ADVISDIR}/${ENSTORM}       # shorthand
 cd ${STORMDIR} 2>> ${SYSLOG}
-THIS=blanton_post.sh
+THIS=$(basename -- $0)
 # get the forecast ensemble member number 
 ENMEMNUM=`grep "forecastEnsembleMemberNumber" ${STORMDIR}/run.properties | sed 's/forecastEnsembleMemberNumber.*://' | sed 's/^\s//'` 2>> ${SYSLOG}
 

--- a/output/queenbee_daily_post.sh
+++ b/output/queenbee_daily_post.sh
@@ -38,7 +38,7 @@ SSHKEY=${13}
 #
 STORMDIR=${ADVISDIR}/${ENSTORM}       # shorthand
 cd ${STORMDIR}
-THIS=queenbee_daily_post.sh
+THIS=$(basename -- $0)
 # get the forecast ensemble member number for use in CERA load balancing
 # as well as picking up any bespoke configuration for this ensemble
 # member in the configuration files

--- a/output/queenbee_daily_post_NGOM.sh
+++ b/output/queenbee_daily_post_NGOM.sh
@@ -38,7 +38,7 @@ SSHKEY=${13}
 #
 STORMDIR=${ADVISDIR}/${ENSTORM}       # shorthand
 cd ${STORMDIR}
-THIS=queenbee_daily_post_NGOM.sh
+THIS=$(basename -- $0)
 # get the forecast ensemble member number for use in CERA load balancing
 # as well as picking up any bespoke configuration for this ensemble
 # member in the configuration files

--- a/output/queenbee_opendap_post.sh
+++ b/output/queenbee_opendap_post.sh
@@ -38,7 +38,7 @@ SSHKEY=${13}
 #
 STORMDIR=${ADVISDIR}/${ENSTORM}       # shorthand
 cd ${STORMDIR}
-THIS=queenbee_daily_post.sh
+THIS=$(basename -- $0)
 # get the forecast ensemble member number for use in CERA load balancing
 # as well as picking up any bespoke configuration for this ensemble
 # member in the configuration files

--- a/output/storm_history.sh
+++ b/output/storm_history.sh
@@ -21,7 +21,7 @@
 # along with the ASGS.  If not, see <http://www.gnu.org/licenses/>.
 #-----------------------------------------------------------------------
 #
-THIS=output/storm_history.sh
+THIS=$(basename -- $0)
 # Count command line arguments; use them if provided or use 
 # run.properties if not.
 declare -A properties
@@ -69,7 +69,6 @@ source ${SCRIPTDIR}/monitoring/logging.sh
 source ${SCRIPTDIR}/platforms.sh
 # dispatch environment (using the functions in platforms.sh)
 env_dispatch ${HPCENVSHORT}
-THIS=output/storm_history.sh
 allMessage "$SCENARIO: $THIS: Starting post processing."
 scenarioMessage "$THIS: SCENARIO=$SCENARIO ; SCENARIODIR=$SCENARIODIR"
 cd ${SCENARIODIR} 2>&1 > errmsg || warn "cycle $CYCLE: $SCENARIO: $THIS: Could not change directory to $SCENARIODIR: `cat $errmsg`"

--- a/output/transmit_rps.sh
+++ b/output/transmit_rps.sh
@@ -20,8 +20,8 @@
 # along with the ASGS.  If not, see <http://www.gnu.org/licenses/>.
 #------------------------------------------------------------------------
 #
-THIS="output/transmit_rps.sh"
-
+THIS=$(basename -- $0)
+#
 declare -A properties
 SCENARIODIR=$PWD
 RUNPROPERTIES=$SCENARIODIR/run.properties

--- a/output/ut-post2017.sh
+++ b/output/ut-post2017.sh
@@ -36,7 +36,7 @@ OUTPUTDIR=${11}
 SYSLOG=${12}
 SSHKEY=${13}
 #
-THIS=ut-post2017.sh
+THIS=$(basename -- $0)
 STORMDIR=${ADVISDIR}/${ENSTORM}       # shorthand
 cd ${STORMDIR}
 # get the forecast ensemble member number for use in CERA load balancing

--- a/output/ut-post2018.sh
+++ b/output/ut-post2018.sh
@@ -36,7 +36,7 @@ OUTPUTDIR=${11}
 SYSLOG=${12}
 SSHKEY=${13}
 #
-THIS=ut-post2018.sh
+THIS=$(basename -- $0)
 STORMDIR=${ADVISDIR}/${ENSTORM}       # shorthand
 cd ${STORMDIR}
 # get the forecast ensemble member number for use in CERA load balancing

--- a/output/wind10m_post.sh
+++ b/output/wind10m_post.sh
@@ -41,7 +41,7 @@ SSHKEY=${13}
 #
 STORMDIR=${ADVISDIR}/${ENSTORM}       # shorthand
 cd ${STORMDIR} 2>> ${SYSLOG}
-THIS=wind10m_post.sh
+THIS=$(basename -- $0)
 # get the forecast ensemble member number 
 ENMEMNUM=`grep "forecastEnsembleMemberNumber" ${STORMDIR}/run.properties | sed 's/forecastEnsembleMemberNumber.*://' | sed 's/^\s//'` 2>> ${SYSLOG}
 #

--- a/platforms.sh
+++ b/platforms.sh
@@ -37,7 +37,7 @@ source ${SCRIPTDIR}/monitoring/logging.sh
 
 init_supermike()
 { #<- can replace the following with a custom script
-  THIS="platforms.sh>env_dispatch()>init_supermike()"
+  local THIS="platforms.sh>env_dispatch()>init_supermike()"
   scenarioMessage "$THIS: Setting platforms-specific parameters."
   HPCENV=mike.hpc.lsu.edu
   QUEUESYS=PBS
@@ -62,7 +62,7 @@ init_supermike()
 #
 init_queenbee()
 { #<- can replace the following with a custom script
-  THIS="platforms.sh>env_dispatch()>init_queenbee()"
+  local THIS="platforms.sh>env_dispatch()>init_queenbee()"
   scenarioMessage "$THIS: Setting platforms-specific parameters."
   HPCENV=queenbee.loni.org
   QUEUESYS=PBS
@@ -98,7 +98,7 @@ init_queenbee()
 #
 init_rostam()
 { #<- can replace the following with a custom script
-  THIS="platforms.sh>env_dispatch()>init_rostam()"
+  local THIS="platforms.sh>env_dispatch()>init_rostam()"
   scenarioMessage "$THIS: Setting platforms-specific parameters."
   HPCENV=rostam.cct.lsu.edu
   QUEUESYS=SLURM
@@ -126,7 +126,7 @@ init_rostam()
 }
 init_supermic()
 { #<- can replace the following with a custom script
-  THIS="platforms.sh>env_dispatch()>init_supermic()"
+  local THIS="platforms.sh>env_dispatch()>init_supermic()"
   scenarioMessage "$THIS: Setting platforms-specific parameters."
   HPCENV=supermic.hpc.lsu.edu
   QUEUESYS=PBS
@@ -148,7 +148,7 @@ init_supermic()
   JOBLAUNCHER='mpirun -np %totalcpu% -machinefile $PBS_NODEFILE'
   ACCOUNT=null
   PERL5LIB=${PERL5LIB}:${SCRIPTDIR}/PERL
-  THIS="platforms.sh>env_dispatch()>init_supermic()"
+  local THIS="platforms.sh>env_dispatch()>init_supermic()"
   SSHKEY=~/.ssh/id_rsa.pub
   REMOVALCMD="rmpurge"
   ARCHIVE=enstorm_pedir_removal.sh
@@ -167,7 +167,7 @@ init_supermic()
 # propagates in the ASGS Shell environment
 
 init_queenbeeC()
-{ THIS="platforms.sh>env_dispatch()>init_queenbeeC()"
+{ local THIS="platforms.sh>env_dispatch()>init_queenbeeC()"
   scenarioMessage "$THIS: Setting platforms-specific parameters."
   HPCENV=qbc.loni.org
   QUEUESYS=SLURM
@@ -193,7 +193,7 @@ init_queenbeeC()
 
 init_pod()
 { #<- can replace the following with a custom script
-  THIS="platforms.sh>env_dispatch()>init_pod()"
+  local THIS="platforms.sh>env_dispatch()>init_pod()"
   scenarioMessage "$THIS: Setting platforms-specific parameters."
   HPCENV=pod.penguincomputing.com
   QUEUESYS=PBS
@@ -213,7 +213,7 @@ init_pod()
   RMQMessaging_Transmit="on"    #  enables message transmission ("on" | "off")
   RMQMessaging_NcoHome="$HOME/local"
   JOBLAUNCHER='mpirun -np %totalcpu% -machinefile $PBS_NODEFILE'
-  THIS="platforms.sh>env_dispatch()>init_pod()"
+  local THIS="platforms.sh>env_dispatch()>init_pod()"
   SSHKEY=~/.ssh/id_rsa.pub
   RESERVATION=null
   PPN=28
@@ -225,7 +225,7 @@ init_pod()
 }
 init_hatteras()
 { #<- can replace the following with a custom script
-  THIS="platforms.sh>env_dispatch()>init_hatteras()"
+  local THIS="platforms.sh>env_dispatch()>init_hatteras()"
   scenarioMessage "$THIS: Setting platforms-specific parameters."
   HPCENV=hatteras.renci.org
   QUEUESYS=SLURM
@@ -268,7 +268,7 @@ init_hatteras()
 #
 init_frontera()
 { #<- can replace the following with a custom script
-  THIS="platforms.sh>env_dispatch()>init_frontera()"
+  local THIS="platforms.sh>env_dispatch()>init_frontera()"
   scenarioMessage "$THIS: Setting platforms-specific parameters."
   HPCENV=frontera.tacc.utexas.edu
   QUEUESYS=SLURM
@@ -298,7 +298,7 @@ init_frontera()
   MATLABEXE=script # "script" means just execute matlab (don't use mex files)
   # specify location of platform- and Operator-specific scripts to
   # set up environment for different types of jobs
-  THIS="platforms.sh>env_dispatch()>init_frontera()"
+  local THIS="platforms.sh>env_dispatch()>init_frontera()"
   ARCHIVE=enstorm_pedir_removal.sh
   ARCHIVEBASE=/corral-tacc/utexas/hurricane/ASGS
   ARCHIVEDIR=2020 # is this used?
@@ -308,7 +308,7 @@ init_frontera()
 #
 init_stampede2()
 { #<- can replace the following with a custom script
-  THIS="platforms.sh>env_dispatch()>init_stampede2()"
+  local THIS="platforms.sh>env_dispatch()>init_stampede2()"
   scenarioMessage "$THIS: Setting platforms-specific parameters."
   HPCENV=stampede2.tacc.utexas.edu
   QUEUESYS=SLURM
@@ -334,7 +334,7 @@ init_stampede2()
   RMQMessaging_Enable="on"              # "on"|"off"
   RMQMessaging_Transmit="on"            #  enables message transmission ("on" | "off")
   RMQMessaging_NcoHome=$WORK/local
-  THIS="platforms.sh>env_dispatch()>init_stampede2()"
+  local THIS="platforms.sh>env_dispatch()>init_stampede2()"
   ARCHIVE=enstorm_pedir_removal.sh
   ARCHIVEBASE=/corral-tacc/utexas/hurricane/ASGS
   ARCHIVEDIR=2020
@@ -344,7 +344,7 @@ init_stampede2()
 #
 init_lonestar5()
 { #<- can replace the following with a custom script
-  THIS="platforms.sh>env_dispatch()>init_lonestar5()"
+  local THIS="platforms.sh>env_dispatch()>init_lonestar5()"
   scenarioMessage "$THIS: Setting platforms-specific parameters."
   HPCENV=lonestar5.tacc.utexas.edu
   QUEUESYS=SLURM
@@ -373,7 +373,7 @@ init_lonestar5()
   RMQMessaging_Enable="on"      # "on"|"off"
   RMQMessaging_Transmit="on"    #  enables message transmission ("on" | "off")
   RMQMessaging_NcoHome=$WORK/local
-  THIS="platforms.sh>env_dispatch()>init_lonestar5()"
+  local THIS="platforms.sh>env_dispatch()>init_lonestar5()"
   ARCHIVE=enstorm_pedir_removal.sh
   ARCHIVEBASE=/corral-tacc/utexas/hurricane/ASGS
   ARCHIVEDIR=2020
@@ -384,7 +384,7 @@ init_lonestar5()
 # docker bootstrap
 init_docker()
 {
-  THIS="platforms.sh>env_dispatch()>init_docker()"
+  local THIS="platforms.sh>env_dispatch()>init_docker()"
   scenarioMessage "$THIS: Setting platforms-specific parameters."
   HPCENV=docker.local
   QUEUESYS=mpiexec
@@ -406,7 +406,7 @@ init_vagrant() {
 
 init_desktop()
 {
-  THIS="platforms.sh>env_dispatch()>init_desktop()"
+  local THIS="platforms.sh>env_dispatch()>init_desktop()"
   scenarioMessage "$THIS: Setting platforms-specific parameters."
   HPCENV=jason-desktop.seahorsecoastal.com
   QUEUESYS=mpiexec
@@ -425,7 +425,7 @@ init_desktop()
 
 init_desktop_serial() # changed from init_desktop-serial due to bash complaints
 {
-  THIS="platforms.sh>env_dispatch()>init_desktop-serial()"
+  local THIS="platforms.sh>env_dispatch()>init_desktop-serial()"
   scenarioMessage "$THIS: Setting platforms-specific parameters."
   HPCENV=jason-desktop-serial
   QUEUESYS=serial
@@ -459,7 +459,7 @@ init_Poseidon()
 }
 init_penguin()
 { #<- can replace the following with a custom script
-  THIS="platforms.sh>env_dispatch()>init_penguin()"
+  local THIS="platforms.sh>env_dispatch()>init_penguin()"
   scenarioMessage "$THIS: Setting platforms-specific parameters."
   HPCENV=pod.penguincomputing.com
   #HOSTNAME=login-29-45.pod.penguincomputing.com
@@ -483,7 +483,7 @@ init_test()
 # and the THREDDS data server the results are to be posted to.
 writeTDSProperties()
 {
-   THIS="platforms.sh>writeTDSProperties()"
+   local THIS="platforms.sh>writeTDSProperties()"
    scenarioMessage "$THIS: Setting platforms-specific parameters for ${SERVER}."
    operator=$USER
    SERVER=$1
@@ -576,7 +576,7 @@ writeTDSProperties()
 #
 # set the values of HPCENV and HPCENVSHORT
 set_hpc() {
-   THIS="platforms.sh>set_hpc()"
+   local THIS="platforms.sh>set_hpc()"
    echo "$THIS: Setting the values of HPCENV and HPCENVSHORT."
    fqdn=`hostname --long`
    echo "$THIS: The fully qualified domain name is ${fqdn}."
@@ -643,7 +643,7 @@ set_hpc() {
 # used to dispatch environmentally sensitive actions
 env_dispatch() {
  HPCENVSHORT=$1
- THIS="platforms.sh>env_dispatch()"
+ local THIS="platforms.sh>env_dispatch()"
  scenarioMessage "$THIS: Initializing settings for ${HPCENVSHORT}."
  echo "(info)    $THIS: Initializing settings for ${HPCENVSHORT}."
  case $HPCENVSHORT in


### PR DESCRIPTION
Issue 573: Added 'local' keyword to assignment to "$THIS" in all
bash functions. When used globally, set "THIS=(basename -- $0)",
which provides consistent naming of "$THIS" across all scripts.

Furthermore, there's no need to reset or "change back" $THIS when
a function is called. This took care of itself when a script that
defined $THIS globally in the script file exited because a child
process can't affect the environment of the parent.

Resolves #573.