### PR TITLE
removing "-assume buffered_io"

### DIFF
--- a/output/cpra_postproc/old/tools/Build_Tools.sh
+++ b/output/cpra_postproc/old/tools/Build_Tools.sh
@@ -3,15 +3,15 @@
 NETCDFHOME=/usr/local/packages/netcdf/4.2.1.1/INTEL-140-MVAPICH2-2.0
 
 echo "Building libraries..."
-ifort -O2 -assume buffered_io -assume byterecl -D_NETCDF -I$NETCDFHOME/include -L$NETCDFHOME/lib -lnetcdf -lnetcdff genericModule.F90 -c
-ifort -O2 -assume buffered_io -assume byterecl -D_NETCDF -I$NETCDFHOME/include -L$NETCDFHOME/lib -lnetcdf -lnetcdff kdtree2Module.F90 -c
-ifort -O2 -assume buffered_io -assume byterecl -D_NETCDF -I$NETCDFHOME/include -L$NETCDFHOME/lib -lnetcdf -lnetcdff adcircModule.F90 -c
-ifort -O2 -assume buffered_io -assume byterecl -D_NETCDF -I$NETCDFHOME/include -L$NETCDFHOME/lib -lnetcdf -lnetcdff imedsModule.F90 -c
-ifort -O2 -assume buffered_io -assume byterecl -D_NETCDF -I$NETCDFHOME/include -L$NETCDFHOME/lib -lnetcdf -lnetcdff dateModule.F90 -c
-ifort -O2 -assume buffered_io -assume byterecl -I$NETCDFHOME/include -L$NETCDFHOME/lib -lnetcdf -lnetcdff adcmesh.F90 -c
+ifort -O2 -assume byterecl -D_NETCDF -I$NETCDFHOME/include -L$NETCDFHOME/lib -lnetcdf -lnetcdff genericModule.F90 -c
+ifort -O2 -assume byterecl -D_NETCDF -I$NETCDFHOME/include -L$NETCDFHOME/lib -lnetcdf -lnetcdff kdtree2Module.F90 -c
+ifort -O2 -assume byterecl -D_NETCDF -I$NETCDFHOME/include -L$NETCDFHOME/lib -lnetcdf -lnetcdff adcircModule.F90 -c
+ifort -O2 -assume byterecl -D_NETCDF -I$NETCDFHOME/include -L$NETCDFHOME/lib -lnetcdf -lnetcdff imedsModule.F90 -c
+ifort -O2 -assume byterecl -D_NETCDF -I$NETCDFHOME/include -L$NETCDFHOME/lib -lnetcdf -lnetcdff dateModule.F90 -c
+ifort -O2 -assume byterecl -I$NETCDFHOME/include -L$NETCDFHOME/lib -lnetcdf -lnetcdff adcmesh.F90 -c
 
 echo "Building netcdf2adcirc..."
-ifort -O2 -assume buffered_io -D_NETCDF netcdf2adcirc.F90 adcmesh.o genericModule.o kdtree2Module.o adcircModule.o dateModule.o imedsModule.o -I$NETCDFHOME/include -L$NETCDFHOME/lib -lnetcdf -lnetcdff -o netcdf2adcirc.exe
+ifort -O2 -D_NETCDF netcdf2adcirc.F90 adcmesh.o genericModule.o kdtree2Module.o adcircModule.o dateModule.o imedsModule.o -I$NETCDFHOME/include -L$NETCDFHOME/lib -lnetcdf -lnetcdff -o netcdf2adcirc.exe
 
 echo "Building Fort61ToIMEDS..."
-ifort -O2 -assume buffered_io Fort61ToIMEDS.F90 genericModule.o kdtree2Module.o adcircModule.o dateModule.o imedsModule.o -I$NETCDFHOME/include -L$NETCDFHOME/lib -lnetcdf -lnetcdff -o Fort61ToIMEDS.exe
+ifort -O2 Fort61ToIMEDS.F90 genericModule.o kdtree2Module.o adcircModule.o dateModule.o imedsModule.o -I$NETCDFHOME/include -L$NETCDFHOME/lib -lnetcdf -lnetcdff -o Fort61ToIMEDS.exe

--- a/patches/ADCIRC/v53release-issue-549/05-issue-550.patch
+++ b/patches/ADCIRC/v53release-issue-549/05-issue-550.patch
@@ -1,0 +1,102 @@
+diff --git a/work/cmplrflags.mk b/work/cmplrflags.mk
+index 0ab9585..8b19b62 100644
+--- a/work/cmplrflags.mk
++++ b/work/cmplrflags.mk
+@@ -226,7 +226,7 @@ ifeq ($(compiler),intel)
+   PPFC            :=  ifort
+   FC            :=  ifort
+   PFC           :=  mpif90
+-  FFLAGS1       :=  $(INCDIRS) -O2 -FI -assume byterecl -132 -xSSE4.2 -assume buffered_io
++  FFLAGS1       :=  $(INCDIRS) -O2 -FI -assume byterecl -132 -xSSE4.2
+   CFLAGS        := $(INCDIRS) -O2 -xSSE4.2 -m64 -mcmodel=medium -DLINUX
+   FLIBS         :=
+   ifeq ($(DEBUG),full)
+@@ -246,51 +246,51 @@ ifeq ($(compiler),intel)
+   endif
+   #
+   ifeq ($(MACHINENAME),stampede2) 
+-     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 -assume buffered_io
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
+      CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 
+      FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 
+      ifeq ($(DEBUG),trace)
+-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 -assume buffered_io
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
+         CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 
+         FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 
+      endif
+   endif
+   ifeq ($(MACHINENAME),frontera) 
+-     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xCORE-AVX512 -assume buffered_io
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xCORE-AVX512
+      CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX512 
+      FLIBS   := $(INCDIRS) -xCORE-AVX512 
+      ifeq ($(DEBUG),trace)
+-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX512 -assume buffered_io
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX512
+         CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX512
+         FLIBS   := $(INCDIRS) -xCORE-AVX512 
+      endif
+   endif
+   ifeq ($(MACHINENAME),queenbee) 
+-     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xSSE4.2 -assume buffered_io
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xSSE4.2
+      CFLAGS  := $(INCDIRS) -O2 -DLINUX -xSSE4.2 
+      FLIBS   := $(INCDIRS) -xSSE4.2 
+      ifeq ($(DEBUG),trace)
+-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xSSE4.2 -assume buffered_io
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xSSE4.2
+         CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xSSE4.2 
+         FLIBS   := $(INCDIRS) -xSSE4.2 
+      endif
+   endif
+   ifeq ($(MACHINENAME),queenbeeC) 
+-     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xCORE-AVX512 -assume buffered_io
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xCORE-AVX512
+      CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX512 
+      FLIBS   := $(INCDIRS) -xCORE-AVX512 
+      ifeq ($(DEBUG),trace)
+-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX512 -assume buffered_io
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX512
+         CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX512 
+         FLIBS   := $(INCDIRS) -xCORE-AVX512 
+      endif
+   endif
+   ifeq ($(MACHINENAME),supermic) 
+-     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xAVX -assume buffered_io
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xAVX
+      CFLAGS  := $(INCDIRS) -O2 -DLINUX -xAVX
+      FLIBS   := $(INCDIRS) -xAVX
+      ifeq ($(DEBUG),trace)
+-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xAVX -assume buffered_io
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xAVX
+         CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX 
+         FLIBS   := $(INCDIRS) -xAVX
+      endif
+@@ -374,7 +374,7 @@ ifeq ($(compiler),intel-ND)
+   PPFC            :=  ifort
+   FC            :=  ifort
+   PFC           :=  mpif90
+-  FFLAGS1       :=  $(INCDIRS) -w -O2 -assume byterecl -132 -i-dynamic -assume buffered_io
++  FFLAGS1       :=  $(INCDIRS) -w -O2 -assume byterecl -132 -i-dynamic
+   ifeq ($(DEBUG),full)
+      FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -debug -check all -i-dynamic -FI -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
+   endif
+@@ -418,7 +418,7 @@ ifeq ($(compiler),intel-sgi)
+   PFC           :=  mpif90
+   CC            :=  icc -O2 -no-ipo
+   CCBE          :=  icc -O2 -no-ipo
+-  FFLAGS1       :=  $(INCDIRS) -fixed -extend-source 132 -O2 -finline-limit=1000 -real-size 64 -no-ipo -assume buffered_io
++  FFLAGS1       :=  $(INCDIRS) -fixed -extend-source 132 -O2 -finline-limit=1000 -real-size 64 -no-ipo
+ #  FFLAGS1      :=  $(INCDIRS) -Mextend -g -O0 -traceback
+   FFLAGS2       :=  $(FFLAGS1)
+   FFLAGS3       :=  $(FFLAGS1) -assume buffered_stdout
+@@ -574,7 +574,7 @@ ifeq ($(compiler),xtintel)
+   PFC           :=  ftn
+   CC            :=  cc -O2 -no-ipo
+   CCBE          :=  cc -O2 -no-ipo
+-  FFLAGS1       :=  $(INCDIRS) -fixed -extend-source 132 -O2 -default64 -finline-limit=1000 -real-size 64 -no-ipo -assume buffered_io
++  FFLAGS1       :=  $(INCDIRS) -fixed -extend-source 132 -O2 -default64 -finline-limit=1000 -real-size 64 -no-ipo
+ #  FFLAGS1      :=  $(INCDIRS) -Mextend -g -O0 -traceback
+   FFLAGS2       :=  $(FFLAGS1)
+   FFLAGS3       :=  $(FFLAGS1) -assume buffered_stdout

--- a/patches/ADCIRC/v55release-issue-549/04-issue-550.patch
+++ b/patches/ADCIRC/v55release-issue-549/04-issue-550.patch
@@ -1,0 +1,152 @@
+diff --git a/thirdparty/swan/macros.inc.queenbee b/thirdparty/swan/macros.inc.queenbee
+index e35a794..cfa6223 100644
+--- a/thirdparty/swan/macros.inc.queenbee
++++ b/thirdparty/swan/macros.inc.queenbee
+@@ -5,7 +5,7 @@ F90_SER = ifort
+ F90_OMP = ifort
+ F90_MPI = mpif90
+ FLAGS_OPT = -O2
+-FLAGS_MSC = -W0 -assume byterecl -traceback -diag-disable 8290 -diag-disable 8291 -diag-disable 8293 -assume buffered_io -xSSE4.2
++FLAGS_MSC = -W0 -assume byterecl -traceback -diag-disable 8290 -diag-disable 8291 -diag-disable 8293 -xSSE4.2
+ FLAGS90_MSC = $(FLAGS_MSC)
+ FLAGS_SER =
+ FLAGS_OMP = -openmp
+diff --git a/thirdparty/swan/macros.inc.stampede2 b/thirdparty/swan/macros.inc.stampede2
+index 651ae8a..dfa2734 100644
+--- a/thirdparty/swan/macros.inc.stampede2
++++ b/thirdparty/swan/macros.inc.stampede2
+@@ -5,7 +5,7 @@ F90_SER = ifort
+ F90_OMP = ifort
+ F90_MPI = mpif90
+ FLAGS_OPT = -O2
+-FLAGS_MSC = -W0 -assume byterecl -traceback -diag-disable 8290 -diag-disable 8291 -diag-disable 8293 -assume buffered_io -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
++FLAGS_MSC = -W0 -assume byterecl -traceback -diag-disable 8290 -diag-disable 8291 -diag-disable 8293 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
+ FLAGS90_MSC = $(FLAGS_MSC)
+ FLAGS_SER =
+ FLAGS_OMP = -openmp
+diff --git a/thirdparty/swan/macros.inc.supermic b/thirdparty/swan/macros.inc.supermic
+index 94d190e..a95927e 100644
+--- a/thirdparty/swan/macros.inc.supermic
++++ b/thirdparty/swan/macros.inc.supermic
+@@ -2,7 +2,7 @@ F90_SER = ifort
+ F90_OMP = ifort
+ F90_MPI = mpif90
+ FLAGS_OPT = -O2
+-FLAGS_MSC = -W0 -assume byterecl -traceback -diag-disable 8290 -diag-disable 8291 -diag-disable 8293 -assume buffered_io -xAVX
++FLAGS_MSC = -W0 -assume byterecl -traceback -diag-disable 8290 -diag-disable 8291 -diag-disable 8293 -xAVX
+ FLAGS90_MSC = $(FLAGS_MSC)
+ FLAGS_SER =
+ FLAGS_OMP = -openmp
+diff --git a/work/cmplrflags.mk b/work/cmplrflags.mk
+index 54a4e6d..115c3d1 100644
+--- a/work/cmplrflags.mk
++++ b/work/cmplrflags.mk
+@@ -229,7 +229,7 @@ ifeq ($(compiler),intel)
+   PPFC            :=  ifort
+   FC            :=  ifort
+   PFC           :=  mpif90
+-  FFLAGS1       :=  $(INCDIRS) -O2 -FI -assume byterecl -132 -xSSE4.2 -assume buffered_io
++  FFLAGS1       :=  $(INCDIRS) -O2 -FI -assume byterecl -132 -xSSE4.2
+   CFLAGS        := $(INCDIRS) -O2 -xSSE4.2 -m64 -mcmodel=medium -DLINUX
+   FLIBS         :=
+   ifeq ($(DEBUG),full)
+@@ -252,60 +252,60 @@ ifeq ($(compiler),intel)
+   endif
+   #
+   ifeq ($(MACHINENAME),stampede2)
+-     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 -assume buffered_io
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
+      CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
+      FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
+      ifeq ($(DEBUG),trace)
+-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 -assume buffered_io
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
+         CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
+         FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
+      endif
+   endif
+   ifeq ($(MACHINENAME),frontera) 
+-     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xCORE-AVX512 -assume buffered_io
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xCORE-AVX512
+      CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX512 
+      FLIBS   := $(INCDIRS) -xCORE-AVX512 
+      ifeq ($(DEBUG),trace)
+-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX512 -assume buffered_io
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX512
+         CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX512
+         FLIBS   := $(INCDIRS) -xCORE-AVX512 
+      endif
+   endif
+   ifeq ($(MACHINENAME),queenbee)
+-     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xSSE4.2 -assume buffered_io
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xSSE4.2
+      CFLAGS  := $(INCDIRS) -O2 -DLINUX -xSSE4.2
+      FLIBS   := $(INCDIRS) -xSSE4.2
+      ifeq ($(DEBUG),trace)
+-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xSSE4.2 -assume buffered_io
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xSSE4.2
+         CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xSSE4.2
+         FLIBS   := $(INCDIRS) -xSSE4.2
+      endif
+   ifeq ($(MACHINENAME),supermic) 
+-     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xAVX -assume buffered_io
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xAVX
+      CFLAGS  := $(INCDIRS) -O2 -DLINUX -xAVX
+      FLIBS   := $(INCDIRS) -xAVX
+      ifeq ($(DEBUG),trace)
+-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xAVX -assume buffered_io
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xAVX
+         CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX 
+         FLIBS   := $(INCDIRS) -xAVX
+      endif
+   endif
+   ifeq ($(MACHINENAME),queenbeeC) 
+-     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xCORE-AVX512 -assume buffered_io
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xCORE-AVX512
+      CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX512 
+      FLIBS   := $(INCDIRS) -xCORE-AVX512 
+      ifeq ($(DEBUG),trace)
+-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX512 -assume buffered_io
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX512
+         CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX512 
+         FLIBS   := $(INCDIRS) -xCORE-AVX512 
+      endif
+   endif
+   ifeq ($(MACHINENAME),supermic) 
+-     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xAVX -assume buffered_io
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xAVX
+      CFLAGS  := $(INCDIRS) -O2 -DLINUX -xAVX
+      FLIBS   := $(INCDIRS) -xAVX
+      ifeq ($(DEBUG),trace)
+-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xAVX -assume buffered_io
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xAVX
+         CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX 
+         FLIBS   := $(INCDIRS) -xAVX
+      endif
+@@ -394,7 +394,7 @@ ifeq ($(compiler),intel-ND)
+   PPFC          :=  ifort
+   FC            :=  ifort
+   PFC           :=  mpif90
+-  FFLAGS1       :=  $(INCDIRS) -w -O2 -assume byterecl -132 -assume buffered_io #-i-dynamic
++  FFLAGS1       :=  $(INCDIRS) -w -O2 -assume byterecl -132 #-i-dynamic
+   ifeq ($(DEBUG),full)
+      FFLAGS1    :=  $(INCDIRS) -g -O0 -traceback -debug -check all -FI -assume byterecl -132 -DEBUG -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
+   endif
+@@ -445,7 +445,7 @@ ifeq ($(compiler),intel-sgi)
+   PFC           :=  mpif90
+   CC            :=  icc -O2 -no-ipo
+   CCBE          :=  icc -O2 -no-ipo
+-  FFLAGS1       :=  $(INCDIRS) -fixed -extend-source 132 -O2 -finline-limit=1000 -real-size 64 -no-ipo -assume buffered_io
++  FFLAGS1       :=  $(INCDIRS) -fixed -extend-source 132 -O2 -finline-limit=1000 -real-size 64 -no-ipo
+ #  FFLAGS1      :=  $(INCDIRS) -Mextend -g -O0 -traceback
+   FFLAGS2       :=  $(FFLAGS1)
+   FFLAGS3       :=  $(FFLAGS1) -assume buffered_stdout
+@@ -601,7 +601,7 @@ ifeq ($(compiler),xtintel)
+   PFC           :=  ftn
+   CC            :=  cc -O2 -no-ipo
+   CCBE          :=  cc -O2 -no-ipo
+-  FFLAGS1       :=  $(INCDIRS) -fixed -extend-source 132 -O2 -default64 -finline-limit=1000 -real-size 64 -no-ipo -assume buffered_io
++  FFLAGS1       :=  $(INCDIRS) -fixed -extend-source 132 -O2 -default64 -finline-limit=1000 -real-size 64 -no-ipo
+ #  FFLAGS1      :=  $(INCDIRS) -Mextend -g -O0 -traceback
+   FFLAGS2       :=  $(FFLAGS1)
+   FFLAGS3       :=  $(FFLAGS1) -assume buffered_stdout


### PR DESCRIPTION
Note, @jasonfleming, these patches are applied to the following ADCIRC patch sets:

* v53release-issue-549
* v55release-issue-549

I figured we could batch them into this, since we're using these to test the supermic fixes. Once
we finally get it licked, I can roll the accumulated patches into the patch sets for the other respective
versions of adcirc