### PR TITLE
Moved RMQ variable initialization 

### DIFF
--- a/asgs_main.sh
+++ b/asgs_main.sh
@@ -1499,16 +1499,6 @@ variables_init()
    # RMQMessaging defaults (can be set in $CONFIG)
    RMQMessaging_Enable=${RMQMessaging_Enable:-off}     # "on"|"off"
    RMQMessaging_Transmit=${RMQMessaging_Transmit:-off} # enables message transmission ("on" | "off")
-   # only set these if enabled in $CONFIG
-   if [[ ${RMQMessaging_Enable} == "on" ]]; then
-     RMQMessaging_Script="${SCRIPTDIR}/monitoring/asgs-msgr.py"
-     RMQMessaging_Script_RP="${SCRIPTDIR}/monitoring/rp2json.py"
-     RMQMessaging_StartupScript="${SCRIPTDIR}/monitoring/asgs-msgr_startup.py"
-     namedot=${HPCENVSHORT}.
-     RMQMessaging_LocationName=${HPCENV#$namedot}
-     RMQMessaging_ClusterName=$HPCENVSHORT
-     unset namedot
-   fi
 }
 
 # Write general properties to the run.properties file that are associated with

--- a/config/2021/asgs_config_PRVI15_nam_jgf.sh
+++ b/config/2021/asgs_config_PRVI15_nam_jgf.sh
@@ -72,6 +72,8 @@ POSTPROCESS=( includeWind10m.sh createOPeNDAPFileList.sh opendap_post.sh transmi
 FINISH_SPINUP_SCENARIO=( output/createOPeNDAPFileList.sh output/opendap_post.sh )
 FINISH_NOWCAST_SCENARIO=( output/createOPeNDAPFileList.sh output/opendap_post.sh )
 OPENDAPNOTIFY="asgs.cera.lsu@gmail.com,jason.g.fleming@gmail.com"
+RMQMessaging_Enable="on"
+RMQMessaging_Transmit="on"
 
 # Initial state (overridden by STATEFILE after ASGS gets going)
 

--- a/config/2021/asgs_config_SABv20a_nam_jgf.sh
+++ b/config/2021/asgs_config_SABv20a_nam_jgf.sh
@@ -72,6 +72,8 @@ FINISH_NOWCAST_SCENARIO=( output/createOPeNDAPFileList.sh output/opendap_post.sh
 FINISH_SPINUP_SCENARIO=( output/createOPeNDAPFileList.sh output/opendap_post.sh )
 POSTPROCESS=( includeWind10m.sh createOPeNDAPFileList.sh opendap_post.sh transmit_rps.sh )
 OPENDAPNOTIFY="asgs.cera.lsu@gmail.com,jason.g.fleming@gmail.com"
+RMQMessaging_Enable="on"
+RMQMessaging_Transmit="on"
 
 # Initial state (overridden by STATEFILE after ASGS gets going)
 

--- a/monitoring/asgs-msgr.sh
+++ b/monitoring/asgs-msgr.sh
@@ -11,9 +11,20 @@ if [[ ! -e ${RMQMessaging_Python} ]] ; then
 	RMQMessaging_Enable="off"
 	return 1
 fi
+RMQMessaging_Script=${RMQMessaging_Script:-$SCRIPTDIR/monitoring/asgs-msgr.py}
+RMQMessaging_Script_RP=${RMQMessaging_Script_RP:-$SCRIPTDIR/monitoring/rp2json.py}
+RMQMessaging_StartupScript=${RMQMessaging_StartupScript:-${SCRIPTDIR}/monitoring/asgs-msgr_startup.py}
+namedot=${HPCENVSHORT}.
+RMQMessaging_LocationName=${RMQMessaging_LocationName:-${HPCENV#$namedot}}
+RMQMessaging_ClusterName=${RMQMessaging_ClusterName:-$HPCENVSHORT}
+unset namedot
+
 echo "RMQMessaging:Python=$RMQMessaging_Python"
 echo "RMQMessaging:Script=$RMQMessaging_Script"
 echo "RMQMessaging:Script_RP=$RMQMessaging_Script_RP"
+echo "RMQMessaging:StartipScript=$RMQMessaging_StartupScript"
+echo "RMQMessaging:LocationName=$RMQMessaging_LocationName"
+echo "RMQMessaging:ClusterName=$RMQMessaging_ClusterName"
 
 if [[ ! -e ${RMQMessaging_Script} ]] ; then 
 	echo "Messaging script not found. Turning off RMQMessaging."


### PR DESCRIPTION
RMQ init moved from `asgs_main.sh->variables_init()` to `monitoring/asgs-msgr.sh` to resolve an issue where these variables were not getting set because their initial default values were set only if messaging was enabled, and this was performed before the config file was read to see if the Operator had enabled the messaging. Resolves #611 