### PR TITLE
Adding DBD::SQLite to ./PERL-MODULES.

### DIFF
--- a/PERL-MODULES
+++ b/PERL-MODULES
@@ -22,3 +22,4 @@ File::ShareDir
 Archive::Zip
 JSON::XS
 YAML::Tiny
+DBD::SQLite


### PR DESCRIPTION
Issue #648: Added DBD::SQLite Perl module to default ASGS
installation.

Resolves #648.

(been wanting to do this for a while)