### PR TITLE
Replace unsupported strftime with external `date` call in awk script.

### DIFF
--- a/monitoring/scenarioStatus.awk
+++ b/monitoring/scenarioStatus.awk
@@ -54,7 +54,8 @@ END {
       # need to write the final job data
       print "{ \"jobtype\" : "jobtype" \"time.submit\" : "submit" \"jobid\" : "jobid" \"time.start\" : "start" \"time.finish\" : "finish" \"time.error\" : "error" }"
       print "]," # end of jobs.status array
-      date=strftime("%Y-%m-%d-T%H:%M:%S%z")
+      # replace strftime with direct call to `date`
+      "date +%Y-%m-%d-T%H:%M:%S%z" | getline date
       print "\"time.scenario.status.lastupdated\" : \""date"\""
       print "}" # end of scenario.status.json
    }

--- a/monitoring/timestamp.awk
+++ b/monitoring/timestamp.awk
@@ -1,5 +1,6 @@
 #!/usr/bin/awk
 BEGIN {
-   date=strftime("%Y-%m-%d-T%H:%M:%S%z")
+   # replace strftime with direct call to `date`
+   "date +%Y-%m-%d-T%H:%M:%S%z" | getline date
 }
 { print "["date"] "level": "this": "$0 }


### PR DESCRIPTION
Issue 661: Uses external call to `date` with "getline" capture of output
in awk to capture formatted date. Improves portability of script.

Resolves #661.