### PR TITLE
Changes for supermic, letsencrypt root CA fallout.

### DIFF
--- a/PERL-MODULES.wget
+++ b/PERL-MODULES.wget
@@ -1,0 +1,1 @@
+Archive::Zip https://www.cpan.org/authors/id/P/PH/PHRED Archive-Zip-1.68 tar.gz

--- a/cloud/general/asgs-brew.pl
+++ b/cloud/general/asgs-brew.pl
@@ -864,16 +864,16 @@ sub get_steps {
             clean       => qq{bash ./cloud/general/init-perlbrew.sh $asgs_install_path/perl5 clean},
 
             # augment existing %ENV (cumulative) - this assumes that perlbrew is installed in $HOME and we're
-            # using perl-5.32.0
+            # using perl-5.34.0
             export_ENV => {
-                PERLBREW_PERL    => { value => q{perl-5.32.0},                                                                  how => q{replace} },
-                PATH             => { value => qq{$asgs_install_path/perl5/bin:$asgs_install_path/perl5/perls/perl-5.32.0/bin}, how => q{prepend} },
+                PERLBREW_PERL    => { value => q{perl-5.34.0},                                                                  how => q{replace} },
+                PATH             => { value => qq{$asgs_install_path/perl5/bin:$asgs_install_path/perl5/perls/perl-5.34.0/bin}, how => q{prepend} },
                 PERLBREW_HOME    => { value => qq{$asgs_install_path/perl5/perlbrew},                                           how => q{replace} },
                 PERL_CPANM_HOME  => { value => qq{$asgs_install_path/perl5/.cpanm},                                             how => q{replace} },
-                PERLBREW_PATH    => { value => qq{$asgs_install_path/perl5/bin:$asgs_install_path/perl5/perls/perl-5.32.0/bin}, how => q{prepend} },
-                PERLBREW_MANPATH => { value => qq{$asgs_install_path/perl5/perlbrew/perls/perl-5.32.0/man},                     how => q{prepend} },
+                PERLBREW_PATH    => { value => qq{$asgs_install_path/perl5/bin:$asgs_install_path/perl5/perls/perl-5.34.0/bin}, how => q{prepend} },
+                PERLBREW_MANPATH => { value => qq{$asgs_install_path/perl5/perlbrew/perls/perl-5.34.0/man},                     how => q{prepend} },
                 PERLBREW_ROOT    => { value => qq{$asgs_install_path/perl5/perlbrew},                                           how => q{replace} },
-                PERL5LIB         => { value => qq{$asgs_install_path/perl5/perls/perl-5.32.0/lib/site_perl/5.28.2/},            how => q{prepend} },
+                PERL5LIB         => { value => qq{$asgs_install_path/perl5/perls/perl-5.34.0/lib/site_perl/5.34.0/},            how => q{prepend} },
             },
             skip_if => sub {
                 my ( $op, $opts_ref ) = @_;

--- a/cloud/general/init-ffmpeg.sh
+++ b/cloud/general/init-ffmpeg.sh
@@ -39,7 +39,7 @@ cd $_ASGS_TMP
 
 # requires NASM 
 if [ ! -e ${NASM_TGZ} ]; then
-  wget https://www.nasm.us/pub/nasm/releasebuilds/${NASM_VERSION}/${NASM_TGZ}
+  wget --no-check-certificate https://www.nasm.us/pub/nasm/releasebuilds/${NASM_VERSION}/${NASM_TGZ}
 fi
 
 rm -rf $NASM_DIR 2> /dev/null
@@ -53,7 +53,7 @@ make install
 cd $_ASGS_TMP
 
 if [ ! -e ${FFMPEG_BZ2} ]; then
-  wget https://ffmpeg.org/releases/${FFMPEG_BZ2}
+  wget --no-check-certificate https://ffmpeg.org/releases/${FFMPEG_BZ2}
 fi
 
 rm -rf $FFMPEG_DIR 2> /dev/null

--- a/cloud/general/init-gnu-units.sh
+++ b/cloud/general/init-gnu-units.sh
@@ -23,7 +23,7 @@ UNITS_TGZ=${UNITS_DIR}.tar.gz
 cd $_ASGS_TMP
 
 if [ ! -e ${UNITS_TGZ} ]; then
-  wget https://ftp.gnu.org/gnu/units/${UNITS_TGZ}
+  wget --no-check-certificate https://ftp.gnu.org/gnu/units/${UNITS_TGZ}
 fi
 
 rm -rf ./$UNITS_DIR 2> /dev/null

--- a/cloud/general/init-gnuplot-noX11.sh
+++ b/cloud/general/init-gnuplot-noX11.sh
@@ -23,7 +23,7 @@ GNUP_TGZ=${GNUP_DIR}.tar.gz
 cd $_ASGS_TMP
 
 if [ ! -e ${GNUP_TGZ} ]; then
-  wget https://pilotfiber.dl.sourceforge.net/project/gnuplot/gnuplot/${GNUP_VERSION}/${GNUP_TGZ}
+  wget --no-check-certificate https://pilotfiber.dl.sourceforge.net/project/gnuplot/gnuplot/${GNUP_VERSION}/${GNUP_TGZ}
 fi
 
 rm -rf ./$GNUP_DIR 2> /dev/null

--- a/cloud/general/init-hdf5.sh
+++ b/cloud/general/init-hdf5.sh
@@ -34,7 +34,7 @@ chmod 700 $_ASGS_TMP
 cd $_ASGS_TMP
 
 if [ ! -e hdf5-1.8.12.tar.gz ]; then
-  wget --verbose https://asgs-static-assets.sfo2.digitaloceanspaces.com/lib/hdf5-1.8.12.tar.gz
+  wget --no-check-certificate https://asgs-static-assets.sfo2.digitaloceanspaces.com/lib/hdf5-1.8.12.tar.gz
 fi
 
 mkdir -p $OPT 2> /dev/null

--- a/cloud/general/init-image-magick.sh
+++ b/cloud/general/init-image-magick.sh
@@ -42,7 +42,7 @@ fi
 cd $_ASGS_TMP
 
 if [ ! -e ${IMAGEMAGICK_VERSION}.tar.gz ]; then 
-  wget https://github.com/ImageMagick/ImageMagick/archive/${IMAGEMAGICK_VERSION}.tar.gz
+  wget --no-check-certificate https://github.com/ImageMagick/ImageMagick/archive/${IMAGEMAGICK_VERSION}.tar.gz
 else
   echo Found $_ASGS_TMP/${IMAGEMAGICK_VERSION}.tar.gz
   rm -rf ./ImageMagic-${IMAGEMAGICK_VERSION} >/dev/null 2>&1

--- a/cloud/general/init-nco.sh
+++ b/cloud/general/init-nco.sh
@@ -24,7 +24,7 @@ NCO_TGZ=${NCO_VERSION}.tar.gz
 cd $_ASGS_TMP
 
 if [ ! -e ${NCO_TGZ} ]; then
-  wget https://github.com/nco/nco/archive/refs/tags/${NCO_TGZ}
+  wget --no-check-certificate https://github.com/nco/nco/archive/refs/tags/${NCO_TGZ}
 fi
 
 rm -rf ./$NCO_DIR 2> /dev/null

--- a/cloud/general/init-netcdf4.sh
+++ b/cloud/general/init-netcdf4.sh
@@ -39,7 +39,7 @@ chmod 700 $_ASGS_TMP
 cd $_ASGS_TMP
 
 if [ ! -e netcdf-4.2.1.1.tar.gz ]; then
-  wget --verbose https://asgs-static-assets.sfo2.digitaloceanspaces.com/lib/netcdf-4.2.1.1.tar.gz
+  wget --no-check-certificate https://asgs-static-assets.sfo2.digitaloceanspaces.com/lib/netcdf-4.2.1.1.tar.gz
 fi
 
 if [ ! -e netcdf-fortran-4.2.tar.gz ]; then

--- a/cloud/general/init-openmpi.sh
+++ b/cloud/general/init-openmpi.sh
@@ -49,7 +49,7 @@ fi
 cd $_ASGS_TMP
 
 if [ ! -e ${OPENMPI_FULL_VERSION}.tar.gz ]; then 
-  wget https://www.open-mpi.org/software/ompi/v${OPENMPI_MAJOR_VERSION}/downloads/${OPENMPI_FULL_VERSION}.tar.gz
+  wget --no-check-certificate https://www.open-mpi.org/software/ompi/v${OPENMPI_MAJOR_VERSION}/downloads/${OPENMPI_FULL_VERSION}.tar.gz
 else
   echo Found $_ASGS_TMP/${OPENMPI_FULL_VERSION}.tar.gz
   rm -rf ./${OPENMPI_FULL_VERSION} >/dev/null 2>&1

--- a/cloud/general/init-perl-modules.sh
+++ b/cloud/general/init-perl-modules.sh
@@ -27,9 +27,33 @@ fi
 echo Installing Perl modules required for ASGS
 
 # ensure CPAN over SSL
-MIRROR="https://www.cpan.org/"
+MIRROR="http://www.cpan.org/"
 
 # install tempermental modules first
+for module in $(cat ./PERL-MODULES.notest); do
+  cpanm --from $MIRROR --notest $module
+done
+
+# install another class of tempermental modules that require
+OLDIFS=$IFS
+IFS=$'\n'
+for line in $(cat ./PERL-MODULES.wget); do
+echo $line
+  module=$(echo $line | awk '{print $1}');
+  mURL=$(echo $line   | awk '{print $2}');
+  base=$(echo $line   | awk '{print $3}');
+  ext=$(echo $line    | awk '{print $4}');
+  pushd /tmp
+  tgz=$base.$ext
+  echo Fetching $module via $mURL/$tgz
+  wget --no-check-certificate $mURL/$tgz
+  cpanm --verbose $tgz
+  rm -v $tgz
+  popd
+done
+IFS=$OLDIFS
+
+# manual fetch via wget
 for module in $(cat ./PERL-MODULES.notest); do
   cpanm --from $MIRROR --notest $module
 done

--- a/cloud/general/init-perlbrew.sh
+++ b/cloud/general/init-perlbrew.sh
@@ -3,7 +3,7 @@
 PERLBREW_ROOT=${1-"$HOME/perl5"}
 export PERLBREW_ROOT
 ACTION=${2-"install"}
-PERL_VERSION=${3-"perl-5.32.0"}
+PERL_VERSION=${3-"perl-5.34.0"}
 
 if [ "$ACTION" == "clean" ]; then
 

--- a/cloud/general/init-python.sh
+++ b/cloud/general/init-python.sh
@@ -22,7 +22,7 @@ chmod 700 $_ASGS_TMP
 cd $_ASGS_TMP
 
 if [ ! -e ./Python-${PYTHON_VERSION}.tgz ]; then
-  wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
+  wget --no-check-certificate https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
 fi
 if [ $? != 0 ]; then
   echo Error downloading Python ${PYTHON_VERSION}. Please check access to the URL:

--- a/cloud/general/t/verify-adcirc.sh
+++ b/cloud/general/t/verify-adcirc.sh
@@ -10,7 +10,7 @@ fi
 
 mkdir -p /tmp/$$-adcirc-test
 pushd /tmp/$$-adcirc-test
-wget https://www.dropbox.com/s/1wk91r67cacf132/NetCDF_shinnecock_inlet.tar.bz2 > /dev/null 2>&1
+wget --no-check-certificate https://www.dropbox.com/s/1wk91r67cacf132/NetCDF_shinnecock_inlet.tar.bz2 > /dev/null 2>&1
 bunzip2 NetCDF_shinnecock_inlet.tar.bz2 > /dev/null 2>&1
 tar xvf NetCDF_shinnecock_inlet.tar > /dev/null 2>&1
 # simple check, so just run for 0.5 days


### PR DESCRIPTION
Issue 667: Fixing a number of issues noticed when trying to build
on supermic (LSU) recently. In addition to their being some issues
with downloading certain Perl modules from CPAN over port 80 http,
there are internet wide issues with the way letsencrypt chose to
expire their root CA. SSL is useless in general, so just turning that
off for downloading all sources used to build using asgs-brew.pl that
require https URLs and wget to fetch the files.

Resolves 667.