### PR TITLE
Allow OPENDAPNOTIFY to be updated in config during runtime.

### DIFF
--- a/output/opendap_post.sh
+++ b/output/opendap_post.sh
@@ -71,8 +71,6 @@ if [[ ${#FILES[@]} -eq 0 ]]; then
    warn "cycle $CYCLE: $SCENARIO: $THIS: No files to post to opendap servers in $RUNPROPERTIES."
    exit
 fi
-OPENDAPNOTIFY="${properties['notification.opendap.email.opendapnotify']}"
-#
 if [[ $SCENARIO == "asgs.instance.status" ]]; then
     statusDir=${properties['path.statusdir']}
     cd ${statusDir} > errmsg 2>&1 || warn "$SCENARIO: $THIS: Failed to change directory to '$statusDir': `cat errmsg`."

--- a/output/opendap_post2.sh
+++ b/output/opendap_post2.sh
@@ -71,8 +71,6 @@ if [[ ${#FILES[@]} -eq 0 ]]; then
    warn "cycle $CYCLE: $SCENARIO: $THIS: No files to post to opendap servers in $RUNPROPERTIES."
    exit
 fi
-OPENDAPNOTIFY="${properties['notification.opendap.email.opendapnotify']}"
-#
 if [[ $SCENARIO == "asgs.instance.status" ]]; then
     statusDir=${properties['path.statusdir']}
     cd ${statusDir} > errmsg 2>&1 || warn "$SCENARIO: $THIS: Failed to change directory to '$statusDir': `cat errmsg`."


### PR DESCRIPTION
Issue 685: OPENDAPNOTIFY was getting derived from run.properties
once set in the initial run via the opendap_post.sh script(s). This
change removes this propagation via run.properties and allows it
to be changed at run time during the configuration file, which is
preferred.

Resolves #685.