### PR TITLE
Added 'jq' as an option post-ASGS-install build step via asgsh.

### DIFF
--- a/cloud/general/DOT-asgs-brew.sh
+++ b/cloud/general/DOT-asgs-brew.sh
@@ -753,20 +753,23 @@ echo " --update-shell option"
 echo
 fi
 
-# runs script to install ADCIRC interactively
-build () {
-  if [ -z "${1}" ]; then
-    echo "The 'build' command requires an argument specifying what to build, e.g., 'build adcirc'"
-    exit
-  fi
+# 'build' is basically ASGS Shell Environment's "package manager"
+# these are the "optional" installs - from individual utilities
+# to "bundles" (e.g., a set of related, but optional Perl modules)
+build() {
   TO_BUILD=${1}
-  case "${1}" in
+  BUILD_OPTS=${2}
+  case "${TO_BUILD}" in
     adcirc)
-      init-adcirc.sh ${2}
+      init-adcirc.sh ${BUILD_OPTS}
+      ;;
+    jq)
+      init-jq.sh ${ASGS_INSTALL_PATH} ${BUILD_OPTS}
       ;;
     *)
-      echo "Only 'adcirc' supported at this time."
-      exit
+      echo 'Supported "build" options:'
+      echo '  adcirc - ADCIRC build wizard supporting different versions and patchsets'
+      echo '  jq     - "a lightweight and flexible command-line JSON processor"'
       ;;
   esac
 }

--- a/cloud/general/init-jq.sh
+++ b/cloud/general/init-jq.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+OPT=${1-$ASGS_INSTALL_PATH}
+COMPILER=$2
+JOBS=${3-1}
+
+if [[ "$COMPILER" == "clean" || "$COMPILER" == "rebuild" ]]; then 
+  echo cleaning jq 
+  pushd $OPT > /dev/null 2>&1
+  rm -vf ./share/man/man1/jq.1
+  rm -vf ./share/doc/jq
+  rm -vf ./lib/libjq.la
+  rm -vf ./lib/libjq.so.1
+  rm -vf ./lib/libjq.so.1.0.4
+  rm -vf ./lib/libjq.a
+  rm -vf ./lib/libjq.so
+  rm -vf ./bin/jq
+  rm -vf ./include/jq.h
+  popd $OPT > /dev/null 2>&1
+
+  # stop here if 'clean', proceed if 'rebuild'
+  if [ "$COMPILER" == "clean" ]; then
+    exit
+  fi
+fi
+
+if [ -x ${OPT}/bin/jq ]; then
+  printf "(warn) 'jq' was found in $OPT/bin/jq; to rebuild run,\n\n\tbuild jq rebuild\n\n"
+  exit
+fi
+
+JQ_VERSION=1.6
+JQ_DIR=jq-${JQ_VERSION}
+JQ_TGZ=${JQ_DIR}.tar.gz
+cd $_ASGS_TMP
+
+if [ ! -e ${JQ_TGZ} ]; then
+  wget --no-check-certificate https://github.com/stedolan/jq/releases/download/${JQ_DIR}/${JQ_TGZ}
+fi
+
+rm -rf ./$JQ_DIR 2> /dev/null
+
+tar zxvf ./$JQ_TGZ
+
+cd $JQ_DIR
+./configure --prefix $ASGS_INSTALL_PATH --without-oniguruma
+make         && \
+make install
+
+# no errors, so clean up
+if [ "$?" == 0 ]; then
+  echo ...cleaning build scripts and downloads
+  cd $_ASGS_TMP
+  rm -rfv ${JQ_DIR}* > /dev/null 2>&1
+  echo
+  echo "Installation of 'jq' appears to have gone well"
+  printf "Output of 'which jq':\n\n\t%s\n" $(which jq)
+  echo
+fi


### PR DESCRIPTION
Issue 692: Extended asgsh's 'build' command to support 'jq'; this
commit is also a demonstration of a path forward towards offering
optional things that don't necessarily need to be added at ASGS
build time. In the future, most new software requests should be
available via what will become a poor man's "package manager".

Comands supported by 'build':

  build adcirc             # invokes ADCIRC patchset wizard
  build jq [clean|rebuild] # standard approach moving ahead
  build avail              # (lists available things to build)

Resolves #692.