### PR TITLE
Adding optional build support for minimal python 3.7.

### DIFF
--- a/cloud/general/DOT-asgs-brew.sh
+++ b/cloud/general/DOT-asgs-brew.sh
@@ -766,10 +766,18 @@ build() {
     jq)
       init-jq.sh ${ASGS_INSTALL_PATH} ${BUILD_OPTS}
       ;;
+    python2)
+      init-python.sh ${ASGS_INSTALL_PATH} ${BUILD_OPTS}
+      ;;
+    python3)
+      init-python37.sh ${ASGS_INSTALL_PATH} ${BUILD_OPTS}
+      ;;
     *)
       echo 'Supported "build" options:'
-      echo '  adcirc - ADCIRC build wizard supporting different versions and patchsets'
-      echo '  jq     - "a lightweight and flexible command-line JSON processor"'
+      echo '  adcirc  - ADCIRC build wizard supporting different versions and patchsets'
+      echo '  jq      - "a lightweight and flexible command-line JSON processor"'
+      echo '  python  - (deprecated) python2 (2.7.18), includes pip module installer"'
+      echo '  python3 - minimal python3 (3.7.10), includes pip3 module installer"'
       ;;
   esac
 }

--- a/cloud/general/asgs-brew.pl
+++ b/cloud/general/asgs-brew.pl
@@ -724,7 +724,7 @@ sub get_steps {
                 CPPFLAGS => { value => qq{-I$asgs_install_path/include}, how => q{append}, separator => q{ } },
                 LDFLAGS  => { value => qq{-L$asgs_install_path/lib},     how => q{append}, separator => q{ } },
 
-                # the following HDF5* vars are needed for netCDF4 python module
+                # the following HDF5* vars are needed in the environment for any netCDF4 python modules
                 HDF5_DIR    => { value => qq{$asgs_install_path},         how => q{replace} },
                 HDF5_LIBDIR => { value => qq{$asgs_install_path/lib},     how => q{replace} },
                 HDF5_INCDIR => { value => qq{$asgs_install_path/include}, how => q{replace} },
@@ -757,7 +757,7 @@ sub get_steps {
             # augment existing %ENV (cumulative)
             export_ENV => {
                 NETCDFHOME     => { value => qq{$asgs_install_path},         how => q{replace} },
-                NETCDF4_DIR    => { value => qq{$asgs_install_path},         how => q{replace} },    # needed for netCDF4 python module
+                NETCDF4_DIR    => { value => qq{$asgs_install_path},         how => q{replace} },    # needed for any netCDF4 python module
                 NETCDF4_LIBDIR => { value => qq{$asgs_install_path/lib},     how => q{replace} },    # needed for netCDF4 python module
                 NETCDF4_INCDIR => { value => qq{$asgs_install_path/include}, how => q{replace} },    # needed for netCDF4 python module
             },
@@ -944,16 +944,16 @@ sub get_steps {
             },
         },
         {
-            # Note: updating the Python 2 version support must be done here and in the
+            # note: updating the python 2 version support must be done here and in the
             # ./cloud/general/init-python.sh script
-            # Note: this installs Python 2, Python 3 is currently not supported (needs a new step entry)
+            # note: this installs python 2, python 3 is currently not supported (needs a new step entry)
             key         => q{python},
-            name        => q{Step for installing Python 2.7.18 and required modules},
-            description => q{Install Python 2.7.18 locally and install required modules},
+            name        => q{step for installing python 2.7.18 and required modules},
+            description => q{install python 2.7.18 locally and install required modules},
             pwd         => q{./},
-            export_ENV  => {
+            export_env  => {
 
-                # putting this in $HOME/python27/asgs/build reflects what perlbrew's default
+                # putting this in $home/python27/asgs/build reflects what perlbrew's default
                 # behavior is doing by putting perl into $HOME/perl5/perlbrew/build/perl-$version
                 PYTHONPATH => { value => $pythonpath,                               how => q{replace} },
                 PATH       => { value => qq{$pythonpath/bin:$asgs_home/.local/bin}, how => q{prepend} },

--- a/cloud/general/init-python37.sh
+++ b/cloud/general/init-python37.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+OPT=${1-$ASGS_INSTALL_PATH}
+COMPILER=$2
+JOBS=${3-1}
+
+PYTHON3VERSION=3.10.2
+PYTHON3DIR=Python-${PYTHON3VERSION}
+PYTHON3TGZ=${PYTHON3DIR}.tgz
+
+if [[ "$COMPILER" == "clean" || "$COMPILER" == "rebuild" ]]; then 
+  echo cleaning python37 
+  cd $OPT/bin
+  rm -rvf pip3.10 pip3 python3.10 python3.10-config pydoc3.10 idle3.10 2to3-3.10 python3-config python3 pydoc3 idle3 2to3
+  cd $OPT/lib
+  rm -rvf libpython3.10.a python3.10 pkgconfig
+  cd $OPT/include
+  rm -rvf ./python3.10
+  cd $OPT/share/man/man1
+  rm -rvf python3.10.1 python3.1
+  cd $_ASGS_TMP
+  rm -rfv ${PYTHON3DIR}* > /dev/null 2>&1
+  exit
+
+  # stop here if 'clean', proceed if 'rebuild'
+  if [ "$COMPILER" == "clean" ]; then
+    exit
+  fi
+fi
+
+if [ -x ${OPT}/bin/python37 ]; then
+  printf "(warn) 'python37' was found in $OPT/bin/python37; to rebuild run,\n\n\tbuild python37 rebuild\n\n"
+  exit
+fi
+
+cd $_ASGS_TMP
+
+if [ ! -e ${PYTHON3TGZ} ]; then
+  wget --no-check-certificate https://www.python.org/ftp/python/3.10.2/Python-3.10.2.tgz 
+fi
+
+rm -rf ./$PYTHON3DIR 2> /dev/null
+
+tar zxvf ./$PYTHON3TGZ
+
+cd $PYTHON3DIR
+./configure --prefix $ASGS_INSTALL_PATH
+make         && \
+make install
+
+exit;
+
+# no errors, so clean up
+if [ "$?" == 0 ]; then
+  echo ...cleaning build scripts and downloads
+  cd $_ASGS_TMP
+  rm -rfv ${PYTHON3DIR}* > /dev/null 2>&1
+  echo
+  echo "Installation of 'python37' appears to have gone well"
+  printf "Output of 'which python37':\n\n\t%s\n" $(which python37)
+  echo
+fi


### PR DESCRIPTION
Issue 727: Python 3.7.10 may now be installed into the ASGS Shell
Environment with the command, `build python3`. It will not conflict
with python (2.7.18). Python 2 will be deprecated before the coming
hurricane season. Also, moving forward python will not be installed
automatically unless it's deemed necessary.

Note: No non-core modules are installed, but `pip3` is installed. If
there are python3 modules that should be included by default, they
will be added to this script when identified.

Resolves #727.