### PR TITLE
Queue script was getting illegal value for failed email.

### DIFF
--- a/qscript.pl
+++ b/qscript.pl
@@ -262,7 +262,7 @@ while(<TEMPLATE>) {
     s/%jobtype%/$jobtype/g;
     # the email address of the ASGS Operator
     if ( $properties{"notification.emailnotify"} eq "yes" ) {
-       s/%notifyuser%/$properties{"notification.hpc.email.notifyuser"}/g;
+       s/%notifyuser%/$properties{"notification.email.job_failed_list"}/g;
     } else {
        s/%notifyuser%/noLineHere/g;
     }


### PR DESCRIPTION
Issue 733: updated qscript.pl to inject the propery email address/
property into the queue script. Issue found while debugging issue
on QBC when running partmesh phase. May be related to bblanton's
issue on ht4, #723 (maybe, need to confirm).

Resolves #733.