### PR TITLE
Added zero padding to --storm if a single digit is passed

### DIFF
--- a/get_atcf.pl
+++ b/get_atcf.pl
@@ -67,7 +67,9 @@ GetOptions(
            "trigger=s" => \$trigger,
            "nhcName=s" => \$nhcName
            );
-#
+
+# zero-pad storm if single digit
+$storm = sprintf qq{%02d}, $storm;
 my $hindcastfile="bal".$storm.$year.".dat";
 my $forecastfile="al".$storm.$year.".fst";
 #


### PR DESCRIPTION
Issue 741: made script more robust by ensuring that a single digit
[0-9] is passed into the script is more properly formed in order to
generate the best track naming scheme, e.g., "balMMYYYYY.dat".

Resolves #741.