### PR TITLE
Improving `list meshes`.

### DIFF
--- a/bin/list
+++ b/bin/list
@@ -5,6 +5,8 @@ if [ -z "$_ASGSH_PID" ]; then
   exit 1;
 fi
 
+source $SCRIPTDIR/monitoring/logging.sh
+
 # list interface for lists of important things (registered ADCIRC builds, ASGS profiles)
 _list() {
   LISTNUM=1
@@ -36,10 +38,37 @@ _list() {
       fi
       ;;
     meshes)
+      ERRORS=0
+      FORCE=${2}
       for m in $(cat $ASGS_MESH_DEFAULTS | grep '")' | sed 's/[")]//g' | awk '{print $1}'); do
         printf "% 2d. %s\n" $LISTNUM $m
+        GRIDNAME=$(echo $m | sed 's/|.*$//')
+        source $ASGS_MESH_DEFAULTS
+        FILE="${INPUTDIR}/${GRIDFILE}"
+        if [ ! -d $INPUTDIR ]; then
+          mkdir -p $INPUTDIR
+        fi
+        if [[ ! -e $FILE || $FORCE ]]; then
+          echo "  Downloading ..."
+          echo "    $MESHURL/$GRIDFILE.xz"
+          echo "    ... -> $FILE"
+          pushd $INPUTDIR > /dev/null  2>&1
+          curl -s $MESHURL/$GRIDFILE.xz > $GRIDFILE.xz
+          unxz -f $GRIDFILE.xz > /dev/null 2>&1
+          STATUS=$?
+          if [ $STATUS != 0 ]; then
+            echo "    (failed !!!) uncompressing $GRIDFILE."
+            ERRORS=$(($ERRORS+1))
+          fi
+          popd > /dev/null 2>&1
+        fi
+        if [ -e $FILE ]; then
+          NE=$(head -n 2 $FILE | tail -n 1 | awk '{print $1}')
+          echo "$NE elements [$m]"
+        fi
         LISTNUM=$(($LISTNUM+1))
       done
+      echo Number of errors getting meshes: $ERRORS
       ;;
     platforms)
       cat $ASGS_PLATFORMS | egrep '^init_' | sed 's/init_//g' | sed 's/()//g' | awk '{print "- " $1}'

--- a/config/mesh_defaults.sh
+++ b/config/mesh_defaults.sh
@@ -33,7 +33,6 @@ UNITOFFSETFILE=null
 SWANTEMPLATE=adcirc_swan_v53_fort.26.template # found in input/meshes/common/swan
 #
 case $GRIDNAME in
-      #
    "LA_v19k-WithUpperAtch_chk")
       #
       INPUTDIR=$SCRIPTDIR/input/meshes/LA_v19k
@@ -322,7 +321,7 @@ case $GRIDNAME in
       UNITOFFSETFILE=unit_offset_nc_inundation_v9.99_rivers.dat
       ;;
    "hsofs_NE-hires_v2_depf2")
-      INPUTDIR=$SCRIPTDIR/input/meshes/hsofs_NE-hires_v2_depf2/
+      INPUTDIR=$SCRIPTDIR/input/meshes/hsofs_NE-hires_v2_depf2
       GRIDFILE=hsofs_NE-hires_v2_depf2.grd
       MESHPROPERTIES=${GRIDFILE}.nc.properties
       CONTROLTEMPLATE=hsofs_NE-hires_v2_depf2.15.template


### PR DESCRIPTION
Issue 781: Downloads each mesh in `config/mesh_defaults.sh`, then
uncompressing it, then reports back the mesh names and number of
elements are present.

Resolves #781.