### PR TITLE
Changed default ASGS log dir to $WORK/log

### DIFF
--- a/monitoring/logging.sh
+++ b/monitoring/logging.sh
@@ -251,7 +251,15 @@ RMQMessageRunProp()
 # set the name of the asgs log file
 setSyslogFileName()
 {
-   SYSLOG=`pwd`/${INSTANCENAME}.asgs-${STARTDATETIME}.$$.log
+   local DATETIME=$(date +'%Y-%h-%d-T%H:%M:%S%z')
+   if [[ ! -d $WORK/log ]]; then
+      mkdir -p $WORK/log
+      echo "[$DATETIME] INFO: Created subdirectory for ASGS log files : '$WORK/log'."
+   else
+      echo "[$DATETIME] INFO: Found subdirectory for ASGS log files : '$WORK/log'."
+   fi
+   SYSLOG=${SYSLOG:-$WORK/log/${INSTANCENAME}.asgs-${STARTDATETIME}.$$.log}
+   consoleMessage "Set ASGS log file parameter SYSLOG to '$SYSLOG'." $SYSLOG
 }
 #
 # write an INFO-level message to the main asgs log file


### PR DESCRIPTION
Resolves #51 ... This is a change in behavior ... previously the ASGS log file `$SYSLOG` was simply dropped in whatever  `$PWD` was set to when `asgs_main.sh` was executed, which was suboptimal, with log files cluttering up my `$HOME`, `$SCRIPTDIR` etc. Now, the default directory for the ASGS log file `$SYSLOG` is set to `$WORK/log` upon startup (creating that directory if necessary). Operators can change $SYSLOG in their ASGS config files if they want to.  