### PR TITLE
Get OPENDAPNOTIFY from run.properties if not present in env.

### DIFF
--- a/output/opendap_post.sh
+++ b/output/opendap_post.sh
@@ -38,6 +38,9 @@ source $SCRIPTDIR/properties.sh
 # load run.properties file into associative array
 loadProperties $RUNPROPERTIES
 echo "Finished loading properties."
+if [[ -z "$OPENDAPNOTIFY" || "$OPENDAPNOTIFY" == "null" ]]; then
+  OPENDAPNOTIFY=${properties['notification.opendap.email.opendapnotify']}
+fi
 CONFIG=${properties['config.file']}
 COLDSTARTDATE=${properties["adcirc.time.coldstartdate"]} # used for the hindcast path
 CYCLEDIR=${properties['path.advisdir']}


### PR DESCRIPTION
Issue 808: Being able to re-run opendap_post.sh using just the
scenario's run.properties file is now possible. Before, OPENDAPNOTIFY
needed to be defined otherwise emails would not send.

This is useful for debugging and for operational / runtime recovery.

Resolves #808.