### PR TITLE
Updating hdf5 and netCDF4, testing LOCK disable.

### DIFF
--- a/cloud/general/asgs-brew.pl
+++ b/cloud/general/asgs-brew.pl
@@ -453,6 +453,7 @@ fi
 # denotes we're in an active asgsh session
 export _ASGSH_PID=\$\$
 export profile=$asgs_default_profile
+export HDF5_USE_FILE_LOCKING=FALSE
 
 # denotes which environmental variables are saved with a profile - includes variables that
 # are meaningful to ASGS Shell, but not set explicitly via asgs-brew.pl
@@ -519,7 +520,7 @@ sub _get_env_summary {
 
         # filter stuff in local %ENV here that we don't want
         # dumped into the profiles
-        next GETENV if grep { m/^$envar$/ } (qw/SCRIPTDIR/);
+        next GETENV if grep { m/^$envar$/ } (qw/SCRIPTDIR HDF5_USE_FILE_LOCKING/);
         $summary .= sprintf( qq{export %s=%s\n}, $envar, $ENV{$envar} // q{} );
 
         # save to generate list of exported variables added to the locally
@@ -717,9 +718,10 @@ sub get_steps {
                 LDFLAGS  => { value => qq{-L$asgs_install_path/lib},     how => q{append}, separator => q{ } },
 
                 # the following HDF5* vars are needed in the environment for any netCDF4 python modules
-                HDF5_DIR    => { value => qq{$asgs_install_path},         how => q{replace} },
-                HDF5_LIBDIR => { value => qq{$asgs_install_path/lib},     how => q{replace} },
-                HDF5_INCDIR => { value => qq{$asgs_install_path/include}, how => q{replace} },
+                HDF5_DIR              => { value => qq{$asgs_install_path},         how => q{replace} },
+                HDF5_LIBDIR           => { value => qq{$asgs_install_path/lib},     how => q{replace} },
+                HDF5_INCDIR           => { value => qq{$asgs_install_path/include}, how => q{replace} },
+                HDF5_USE_FILE_LOCKING => { value => q{FALSE}, how => q{replace} },
             },
             skip_if => sub {
                 my ( $op, $opts_ref ) = @_;

--- a/cloud/general/init-hdf5.sh
+++ b/cloud/general/init-hdf5.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
-OPT=${1-$HOME/opt}
-COMPILER=${2-intel}
-JOBS=${3-1}
+OPT=${1:-$ASGS_INSTALL_PATH}
+COMPILER=${2:-intel}
+JOBS=${3:-1}
+HDF5_VERSION=${4:-1.12.2}
+
+# may need to make this available in asgs generally
+HDF5_USE_FILE_LOCKING=FALSE
 
 _TMPDIR=${TMPDIR:-/tmp/${USER}-asgs}
 _ASGS_TMP=${_ASGS_TMP:-$_TMPDIR}
@@ -15,7 +19,7 @@ if [ $2 == "clean" ]; then
   rm -fv libhd5* libhdf5*
   cd $OPT/include
   rm -fv H5* h5* hd5* HD5* hdf* typesizes.mod
-  rm -rvf $_ASGS_TMP/hdf5-1.8.12*
+  rm -rvf $_ASGS_TMP/hdf5-${HDF5_VFERSION}*
   cd $OPT/share
   rm -rvf hdf5_examples
   exit
@@ -38,15 +42,15 @@ mkdir -p $_ASGS_TMP 2> /dev/null
 chmod 700 $_ASGS_TMP
 cd $_ASGS_TMP
 
-if [ ! -e hdf5-1.8.12.tar.gz ]; then
-  wget --no-check-certificate https://asgs-static-assets.sfo2.digitaloceanspaces.com/lib/hdf5-1.8.12.tar.gz
+if [ ! -e hdf5-${HDF5_VERSION}.tar.gz ]; then
+  wget --no-check-certificate https://asgs-static-assets.sfo2.digitaloceanspaces.com/lib/hdf5-${HDF5_VERSION}.tar.gz
 fi
 
 mkdir -p $OPT 2> /dev/null
 
 if [ ! -e $OPT/bin/h5diff ]; then
-  tar zxvf hdf5-1.8.12.tar.gz
-  cd hdf5-1.8.12
+  tar zxvf hdf5-${HDF5_VERSION}.tar.gz
+  cd hdf5-${HDF5_VERSION}
   make clean
   ./configure --prefix $OPT --enable-fortran
   make -j $JOBS install

--- a/cloud/general/init-netcdf4.sh
+++ b/cloud/general/init-netcdf4.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
-OPT=${1-$ASGS_INSTALL_PATH}
-COMPILER=${2-intel}
-JOBS=${3-1}
+OPT=${1:-$ASGS_INSTALL_PATH}
+COMPILER=${2:-intel}
+JOBS=${3:-1}
+NETCDF4_C_VERSION=${4:-"c-4.8.1"}
+NETCDF4_F_VERSION=${5:-"4.5.4"};
+
+HDF5_USE_FILE_LOCKING=FALSE
+
+_TMPDIR=${TMPDIR:-/tmp/${USER}-asgs}
+_ASGS_TMP=${_ASGS_TMP:-$_TMPDIR}
 
 if [ $2 == "clean" ]; then 
   echo Cleaning NetCDF libraries and utilities
@@ -12,8 +19,8 @@ if [ $2 == "clean" ]; then
   rm -fv libnetcdf*
   cd $OPT/include
   rm -fv netcdf*
-  rm -rvf $_ASGS_TMP/netcdf-4.2.1.1*
-  rm -rvf $_ASGS_TMP/netcdf-fortran-4.2*
+  rm -rvf $_ASGS_TMP/netcdf-${NETCDF4_C_VERSION}*
+  rm -rvf $_ASGS_TMP/netcdf-fortran-${NETCDF_F_VERSION}*
   cd $OPT/share/info
   rm -rvf netcfg*
   cd $OPT/share/man/man1
@@ -38,19 +45,19 @@ mkdir -p $_ASGS_TMP 2> /dev/null
 chmod 700 $_ASGS_TMP
 cd $_ASGS_TMP
 
-if [ ! -e netcdf-4.2.1.1.tar.gz ]; then
-  wget --no-check-certificate https://asgs-static-assets.sfo2.digitaloceanspaces.com/lib/netcdf-4.2.1.1.tar.gz
+if [ ! -e netcdf-${NETCDF4_C_VERSION}.tar.gz ]; then
+  wget --no-check-certificate https://asgs-static-assets.sfo2.digitaloceanspaces.com/lib/netcdf-${NETCDF4_C_VERSION}.tar.gz
 fi
 
-if [ ! -e netcdf-fortran-4.2.tar.gz ]; then
-  wget --verbose https://asgs-static-assets.sfo2.digitaloceanspaces.com/lib/netcdf-fortran-4.2.tar.gz
+if [ ! -e netcdf-fortran-${NETCDF4_F_VERSION}.tar.gz ]; then
+  wget --verbose https://asgs-static-assets.sfo2.digitaloceanspaces.com/lib/netcdf-fortran-${NETCDF4_F_VERSION}.tar.gz
 fi
 
 mkdir -p $OPT 2> /dev/null
 
 if [ ! -e $OPT/bin/nc-config ]; then
-  tar zxvf netcdf-4.2.1.1.tar.gz
-  cd netcdf-4.2.1.1
+  tar zxvf netcdf-${NETCDF4_C_VERSION}.tar.gz
+  cd netcdf-${NETCDF4_C_VERSION}
   make clean
   ./configure --prefix $OPT
   make -j $JOBS install
@@ -63,8 +70,8 @@ if [ ! -e $OPT/bin/nc-config ]; then
 fi
 
 if [  ! -e $OPT/bin/nf-config ] && [ -z "$($OPT/bin/nf-config --all  | grep '\-\-has\-f90   \-> yes')" ]; then
-  tar zxvf netcdf-fortran-4.2.tar.gz
-  cd netcdf-fortran-4.2
+  tar zxvf netcdf-fortran-${NETCDF4_F_VERSION}.tar.gz
+  cd netcdf-fortran-${NETCDF4_F_VERSION}
   make clean
   ./configure --prefix $OPT
   make -j $JOBS install


### PR DESCRIPTION
Issue 713: Updating the version of HDF5 and netCDF4, including
the disabling of the HDF5 locking that was introduced after
1.8.12 - which is incidentally the last "working" version of
netCDF on some platforms, in particular LSU's supermic.

Resolves #713.