### PR TITLE
Ensure STORM is zero-padded for single number storms.

### DIFF
--- a/asgs_main.sh
+++ b/asgs_main.sh
@@ -53,6 +53,10 @@ readConfig()
    source ${SCRIPTDIR}/config/forcing_defaults.sh
    # pick up config parameters, set by the Operator, that differ from the defaults
    source ${CONFIG}
+   # ensure single digit STORM numbers issued by NHC are zero-padded
+   if [ -n "${STORM}" ]; then
+     STORM=$(printf "%02d" "$STORM")
+   fi
    # maintain backward compatibility with old config files
    if [[ $ENSEMBLESIZE != "null" ]]; then
        SCENARIOPACKAGESIZE=$ENSEMBLESIZE


### PR DESCRIPTION
Issue 827: This change conditions $STORM setting by zero padding
single numbers set in a configuration file; this is a common mistake
that happens during operations, and zero padding is required for
scripts used through the operation forecast runs. It is also required
for properly constructing the full storm designations issued by
the NHC.

Resolves #827.