### PR TITLE
Initial port for LSU/HPC Super Mike III.

### DIFF
--- a/bin/init-adcirc.sh
+++ b/bin/init-adcirc.sh
@@ -135,9 +135,9 @@ if [ "$INTERACTIVE" == "yes" ]; then
   echo
   # determine what to name the ADCIRC profile
   if [ -n "$PATCHSET_NAME" ]; then
-    __ADCIRC_PROFILE_NAME=${PATCHSET_NAME}-${ADCIRC_COMPILER}
+    __ADCIRC_PROFILE_NAME=${PATCHSET_NAME}-${ADCIRC_COMPILER}-${ASGS_MACHINE_NAME}
   else
-    __ADCIRC_PROFILE_NAME=${ADCIRC_GIT_BRANCH}-${ADCIRC_COMPILER}
+    __ADCIRC_PROFILE_NAME=${ADCIRC_GIT_BRANCH}-${ADCIRC_COMPILER}-${ASGS_MACHINE_NAME}
   fi
   read -p "What would you like to name this ADCIRC build profile? [$__ADCIRC_PROFILE_NAME] " _ADCIRC_PROFILE_NAME
   if [ -n "$_ADCIRC_PROFILE_NAME" ]; then

--- a/patches/ADCIRC/v53release-adcircpolate/08-issue-840-supermike-iii.patch
+++ b/patches/ADCIRC/v53release-adcircpolate/08-issue-840-supermike-iii.patch
@@ -1,0 +1,62 @@
+diff --git a/work/cmplrflags.mk b/work/cmplrflags.mk
+index ab80a66..2fc5063 100644
+--- a/work/cmplrflags.mk
++++ b/work/cmplrflags.mk
+@@ -315,6 +315,20 @@ ifeq ($(compiler),intel)
+         FLIBS   := $(INCDIRS)
+      endif
+   endif
++  #wwlwpd: NOTE: Mike III at LSU-HPC recommends 'mpiifort', Intel's MPI implementation wrapper
++  #wwlwpd: instead of the traditional "mpif90"; but the flags are the same we still redefine
++  #wwlwpd: "PFC" below
++  ifeq ($(MACHINENAME),mike)
++     PFC     :=  mpiifort
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xAVX
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xAVX
++     FLIBS   := $(INCDIRS) -xAVX
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xAVX
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX
++        FLIBS   := $(INCDIRS) -xAVX
++     endif
++  endif
+   endif
+   #
+   #@jasonfleming Added to fix bus error on hatteras@renci
+@@ -336,21 +350,21 @@ ifeq ($(compiler),intel)
+   MSGLIBS       :=
+   ifeq ($(NETCDF),enable)
+      ifeq ($(MACHINENAME),hatteras)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      # jgf20150417 queenbee requires that the analyst load the netcdf and
+      # netcdf_fortran modules prior to compiling or executing ADCIRC
+      ifeq ($(MACHINENAME),queenbee)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),queenbeeC)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),supermic)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),rostam)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),stampede)
+         FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+@@ -369,6 +383,9 @@ ifeq ($(compiler),intel)
+      ifeq ($(MACHINENAME),ls6)
+         FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
++     ifeq ($(MACHINENAME),mike)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
+      # jgf20150817: Adding support for spirit.afrl.hpc.mil;
+      # load the following modules: netcdf-fortran/intel/4.4.2
+      # and hdf5/intel/1.8.12 and hdf5-mpi/intel/sgimpt/1.8.12

--- a/patches/ADCIRC/v53release-testsuite/08-issue-840-supermike-iii.patch
+++ b/patches/ADCIRC/v53release-testsuite/08-issue-840-supermike-iii.patch
@@ -1,0 +1,62 @@
+diff --git a/work/cmplrflags.mk b/work/cmplrflags.mk
+index ab80a66..2fc5063 100644
+--- a/work/cmplrflags.mk
++++ b/work/cmplrflags.mk
+@@ -315,6 +315,20 @@ ifeq ($(compiler),intel)
+         FLIBS   := $(INCDIRS)
+      endif
+   endif
++  #wwlwpd: NOTE: Mike III at LSU-HPC recommends 'mpiifort', Intel's MPI implementation wrapper
++  #wwlwpd: instead of the traditional "mpif90"; but the flags are the same we still redefine
++  #wwlwpd: "PFC" below
++  ifeq ($(MACHINENAME),mike)
++     PFC     :=  mpiifort
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xAVX
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xAVX
++     FLIBS   := $(INCDIRS) -xAVX
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xAVX
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX
++        FLIBS   := $(INCDIRS) -xAVX
++     endif
++  endif
+   endif
+   #
+   #@jasonfleming Added to fix bus error on hatteras@renci
+@@ -336,21 +350,21 @@ ifeq ($(compiler),intel)
+   MSGLIBS       :=
+   ifeq ($(NETCDF),enable)
+      ifeq ($(MACHINENAME),hatteras)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      # jgf20150417 queenbee requires that the analyst load the netcdf and
+      # netcdf_fortran modules prior to compiling or executing ADCIRC
+      ifeq ($(MACHINENAME),queenbee)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),queenbeeC)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),supermic)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),rostam)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),stampede)
+         FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+@@ -369,6 +383,9 @@ ifeq ($(compiler),intel)
+      ifeq ($(MACHINENAME),ls6)
+         FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
++     ifeq ($(MACHINENAME),mike)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
+      # jgf20150817: Adding support for spirit.afrl.hpc.mil;
+      # load the following modules: netcdf-fortran/intel/4.4.2
+      # and hdf5/intel/1.8.12 and hdf5-mpi/intel/sgimpt/1.8.12

--- a/patches/ADCIRC/v53release/09-issue-840-supermike-iii.patch
+++ b/patches/ADCIRC/v53release/09-issue-840-supermike-iii.patch
@@ -1,0 +1,62 @@
+diff --git a/work/cmplrflags.mk b/work/cmplrflags.mk
+index ab80a66..2fc5063 100644
+--- a/work/cmplrflags.mk
++++ b/work/cmplrflags.mk
+@@ -315,6 +315,20 @@ ifeq ($(compiler),intel)
+         FLIBS   := $(INCDIRS)
+      endif
+   endif
++  #wwlwpd: NOTE: Mike III at LSU-HPC recommends 'mpiifort', Intel's MPI implementation wrapper
++  #wwlwpd: instead of the traditional "mpif90"; but the flags are the same we still redefine
++  #wwlwpd: "PFC" below
++  ifeq ($(MACHINENAME),mike)
++     PFC     :=  mpiifort
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xAVX
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xAVX
++     FLIBS   := $(INCDIRS) -xAVX
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xAVX
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX
++        FLIBS   := $(INCDIRS) -xAVX
++     endif
++  endif
+   endif
+   #
+   #@jasonfleming Added to fix bus error on hatteras@renci
+@@ -336,21 +350,21 @@ ifeq ($(compiler),intel)
+   MSGLIBS       :=
+   ifeq ($(NETCDF),enable)
+      ifeq ($(MACHINENAME),hatteras)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      # jgf20150417 queenbee requires that the analyst load the netcdf and
+      # netcdf_fortran modules prior to compiling or executing ADCIRC
+      ifeq ($(MACHINENAME),queenbee)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),queenbeeC)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),supermic)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),rostam)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),stampede)
+         FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+@@ -369,6 +383,9 @@ ifeq ($(compiler),intel)
+      ifeq ($(MACHINENAME),ls6)
+         FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
++     ifeq ($(MACHINENAME),mike)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
+      # jgf20150817: Adding support for spirit.afrl.hpc.mil;
+      # load the following modules: netcdf-fortran/intel/4.4.2
+      # and hdf5/intel/1.8.12 and hdf5-mpi/intel/sgimpt/1.8.12

--- a/patches/ADCIRC/v55.01-5bc04d6/07-issue-840-supermike-iii.patch
+++ b/patches/ADCIRC/v55.01-5bc04d6/07-issue-840-supermike-iii.patch
@@ -1,0 +1,62 @@
+diff --git a/work/cmplrflags.mk b/work/cmplrflags.mk
+index edb616b..bec0be5 100644
+--- a/work/cmplrflags.mk
++++ b/work/cmplrflags.mk
+@@ -310,6 +310,20 @@ ifeq ($(compiler),intel)
+         FLIBS   := $(INCDIRS)
+      endif
+   endif
++  #wwlwpd: NOTE: Mike III at LSU-HPC recommends 'mpiifort', Intel's MPI implementation wrapper
++  #wwlwpd: instead of the traditional "mpif90"; but the flags are the same we still redefine
++  #wwlwpd: "PFC" below
++  ifeq ($(MACHINENAME),mike)
++     PFC     :=  mpiifort
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xAVX
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xAVX
++     FLIBS   := $(INCDIRS) -xAVX
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xAVX
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX
++        FLIBS   := $(INCDIRS) -xAVX
++     endif
++  endif
+   #
+   #@jasonfleming Added to fix bus error on hatteras@renci
+   ifeq ($(HEAP_ARRAYS),fix)
+@@ -330,21 +344,21 @@ ifeq ($(compiler),intel)
+   MSGLIBS       :=
+   ifeq ($(NETCDF),enable)
+      ifeq ($(MACHINENAME),hatteras)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      # jgf20150417 queenbee requires that the analyst load the netcdf and
+      # netcdf_fortran modules prior to compiling or executing ADCIRC
+      ifeq ($(MACHINENAME),queenbee)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff lnetcdf
+      endif
+      ifeq ($(MACHINENAME),queenbeeC)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),supermic)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),rostam)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),stampede)
+         FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+@@ -364,6 +378,9 @@ ifeq ($(compiler),intel)
+      ifeq ($(MACHINENAME),ls6)
+         FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
++     ifeq ($(MACHINENAME),mike)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
+      # jgf20150817: Adding support for spirit.afrl.hpc.mil;
+      # load the following modules: netcdf-fortran/intel/4.4.2
+      # and hdf5/intel/1.8.12 and hdf5-mpi/intel/sgimpt/1.8.12

--- a/patches/ADCIRC/v55.01/07-issue-840-supermike-iii.patch
+++ b/patches/ADCIRC/v55.01/07-issue-840-supermike-iii.patch
@@ -1,0 +1,62 @@
+diff --git a/work/cmplrflags.mk b/work/cmplrflags.mk
+index edb616b..bec0be5 100644
+--- a/work/cmplrflags.mk
++++ b/work/cmplrflags.mk
+@@ -310,6 +310,20 @@ ifeq ($(compiler),intel)
+         FLIBS   := $(INCDIRS)
+      endif
+   endif
++  #wwlwpd: NOTE: Mike III at LSU-HPC recommends 'mpiifort', Intel's MPI implementation wrapper
++  #wwlwpd: instead of the traditional "mpif90"; but the flags are the same we still redefine
++  #wwlwpd: "PFC" below
++  ifeq ($(MACHINENAME),mike)
++     PFC     :=  mpiifort
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xAVX
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xAVX
++     FLIBS   := $(INCDIRS) -xAVX
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xAVX
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX
++        FLIBS   := $(INCDIRS) -xAVX
++     endif
++  endif
+   #
+   #@jasonfleming Added to fix bus error on hatteras@renci
+   ifeq ($(HEAP_ARRAYS),fix)
+@@ -330,21 +344,21 @@ ifeq ($(compiler),intel)
+   MSGLIBS       :=
+   ifeq ($(NETCDF),enable)
+      ifeq ($(MACHINENAME),hatteras)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      # jgf20150417 queenbee requires that the analyst load the netcdf and
+      # netcdf_fortran modules prior to compiling or executing ADCIRC
+      ifeq ($(MACHINENAME),queenbee)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff lnetcdf
+      endif
+      ifeq ($(MACHINENAME),queenbeeC)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),supermic)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),rostam)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),stampede)
+         FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+@@ -364,6 +378,9 @@ ifeq ($(compiler),intel)
+      ifeq ($(MACHINENAME),ls6)
+         FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
++     ifeq ($(MACHINENAME),mike)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
+      # jgf20150817: Adding support for spirit.afrl.hpc.mil;
+      # load the following modules: netcdf-fortran/intel/4.4.2
+      # and hdf5/intel/1.8.12 and hdf5-mpi/intel/sgimpt/1.8.12

--- a/patches/ADCIRC/v55release/09-issue-840-supermike-iii.patch
+++ b/patches/ADCIRC/v55release/09-issue-840-supermike-iii.patch
@@ -1,0 +1,62 @@
+diff --git a/work/cmplrflags.mk b/work/cmplrflags.mk
+index f24f7ea..36b7663 100644
+--- a/work/cmplrflags.mk
++++ b/work/cmplrflags.mk
+@@ -315,6 +315,20 @@ ifeq ($(compiler),intel)
+         FLIBS   := $(INCDIRS)
+      endif
+   endif
++  #wwlwpd: NOTE: Mike III at LSU-HPC recommends 'mpiifort', Intel's MPI implementation wrapper
++  #wwlwpd: instead of the traditional "mpif90"; but the flags are the same we still redefine
++  #wwlwpd: "PFC" below
++  ifeq ($(MACHINENAME),mike)
++     PFC     :=  mpiifort
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xAVX
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xAVX
++     FLIBS   := $(INCDIRS) -xAVX
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xAVX
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX
++        FLIBS   := $(INCDIRS) -xAVX
++     endif
++  endif
+   #
+   #@jasonfleming Added to fix bus error on hatteras@renci
+   ifeq ($(HEAP_ARRAYS),fix)
+@@ -335,21 +349,21 @@ ifeq ($(compiler),intel)
+   MSGLIBS       :=
+   ifeq ($(NETCDF),enable)
+      ifeq ($(MACHINENAME),hatteras)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      # jgf20150417 queenbee requires that the analyst load the netcdf and
+      # netcdf_fortran modules prior to compiling or executing ADCIRC
+      ifeq ($(MACHINENAME),queenbee)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),queenbeeC)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),supermic)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),rostam)
+-        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -L$(NETCDFHOME)/lib -lnetcdf -lnetcdf
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),stampede)
+         FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+@@ -369,6 +383,9 @@ ifeq ($(compiler),intel)
+      ifeq ($(MACHINENAME),ls6)
+         FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
++     ifeq ($(MACHINENAME),mike)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
+      # jgf20150817: Adding support for spirit.afrl.hpc.mil;
+      # load the following modules: netcdf-fortran/intel/4.4.2
+      # and hdf5/intel/1.8.12 and hdf5-mpi/intel/sgimpt/1.8.12

--- a/platforms/mike/about.txt
+++ b/platforms/mike/about.txt
@@ -1,0 +1,1 @@
+SuperMike III LSU HPC

--- a/platforms/mike/init.sh
+++ b/platforms/mike/init.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Needed for ./init-asgs.sh, bin/guess
+export WORK=${WORK:-/work/$USER}
+export SCRATCH=${SCRATCH:-$WORK}
+export DEFAULT_COMPILER=intel
+
+# replacement for set_hpc() function in platforms.sh
+export HPCENV=mike.hpc.lsu.edu
+export HPCENVSHORT=mike
+
+export RMQMessaging_Enable="off"
+export HPCENV=mike.hpc.lsu.edu
+export QUEUESYS=SLURM
+export QCHECKCMD=squeue
+export QSUMMARYCMD=squeue
+export QUOTACHECKCMD=null
+export ALLOCCHECKCMD=null
+export QUEUENAME=workq
+export SERQUEUE=single
+export ACCOUNT=null
+export SUBMITSTRING=sbatch
+export JOBLAUNCHER='srun -N %nnodes%'
+export ARCHIVE=enstorm_pedir_removal.sh
+export ARCHIVEBASE=$SCRATCH
+export ARCHIVEDIR=$SCRATCH
+export SSHKEY=~/.ssh/id_rsa.pub
+export QSCRIPTTEMPLATE=$SCRIPTDIR/qscript.template
+export QSCRIPTGEN=qscript.pl
+export OPENDAPPOST=opendap_post2.sh
+export PPN=64
+export CONSTRAINT=null
+export RESERVATION=null
+export REMOVALCMD="rm"
+export TDS=( lsu_tds )
+export MAKEJOBS=8


### PR DESCRIPTION
Issue 840: Changes include updates to patchsets and an update to
the init-adcirc.sh script, which by default appends the machine name
to the profile name (and by extension, the build directory) because
Super Mike III shares the same /work as the current "Super Mic" cluster
but it doesn't share $HOME.

Resolves #840.