### PR TITLE
Updated RMQ message to name correct wind product, confirmed asgs-msgr…

### DIFF
--- a/downloadGFS.sh
+++ b/downloadGFS.sh
@@ -42,7 +42,7 @@ downloadGFS()
     #
     THIS="asgs_main.sh>downloadGFS.sh"
     CURRENT_STATE="WAIT"
-    RMQMessage "INFO" "$CURRENT_EVENT" "$THIS>$ENSTORM" "$CURRENT_STATE"  "Downloading NAM meteorological data for $ENSTORM."
+    RMQMessage "INFO" "$CURRENT_EVENT" "$THIS>$ENSTORM" "$CURRENT_STATE"  "Downloading GFS meteorological data for $ENSTORM."
     logMessage "$ENSTORM: $THIS: Downloading GFS meteorological data."
     cd $RUNDIR 2>> ${SYSLOG}
     #

--- a/monitoring/asgs-msgr.py
+++ b/monitoring/asgs-msgr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import sys
 import datetime
 import getopt

--- a/monitoring/asgs-msgr.sh
+++ b/monitoring/asgs-msgr.sh
@@ -4,7 +4,7 @@ THIS=$(basename -- $0)
 
 echo "RMQMessaging:Validating Message Service..."
 
-RMQMessaging_Python=$(which python3); # should be using python provided by ASGS environment
+RMQMessaging_Python=python3 ; # should be using python provided by ASGS environment
 
 if [[ ! -e ${RMQMessaging_Python} ]] ; then 
 	echo "Specified Python (${RMQMessaging_Python}) not found. Turning off RMQMessaging."

--- a/monitoring/asgs-msgr.sh
+++ b/monitoring/asgs-msgr.sh
@@ -4,7 +4,7 @@ THIS=$(basename -- $0)
 
 echo "RMQMessaging:Validating Message Service..."
 
-RMQMessaging_Python=$(which python); # should be using python provided by ASGS environment
+RMQMessaging_Python=$(which python3); # should be using python provided by ASGS environment
 
 if [[ ! -e ${RMQMessaging_Python} ]] ; then 
 	echo "Specified Python (${RMQMessaging_Python}) not found. Turning off RMQMessaging."


### PR DESCRIPTION
This should address issue 884, where asgs-msgr.sh and asgs-msgr.py both use /usr/bin/python, which is the system python 2 (at least on hatteras). Now it will use python3, which should always be the ASGS python 3 when run via asgsh.

I also snuck in a change to an RMQ message in downloadGFS.sh that was confusing me for a bit in the console output. Now it should rightly print "GFS" when downloading GFS data instead of "NAM".

---

I've run into no errors from any of these changes, but I should caveat this with the fact that I'm still struggling to get my ASGS instance working as expected. If these changes introduced problems, depending on how subtle, it could be harder for me to catch them at present.