### PR TITLE
Adding support for local, custom ADCIRC src.

### DIFF
--- a/bin/init-adcirc.sh
+++ b/bin/init-adcirc.sh
@@ -25,14 +25,16 @@
 # before running 'build adcirc' in asgsh
 #
 
+I="(info)"
+W="(!! warning)"
+
 if [ "${1}" = "clean" ]; then
   echo "'clean' not implemented for optional ADCIRC/SWAN step at this time, clean up for ADCIRC and SWAN must be done manually."
   exit 0
 fi
 
-
 ADCIRCS=()
-NUM_ADC=${#ADCIRCS[@]}
+NUM_ADC=0
 
 # support function for menu detecting selection
 _is_a_num()
@@ -55,20 +57,24 @@ _show_supported_versions()
   echo  '|~~~VERSION~~~~~~~~~~~~~~~~~~~~~~~~~~~~~DESCRIPTION'
   for VERSION in $(ls -1 $SCRIPTDIR/patches/ADCIRC); do 
     _ADCIRCS="$_ADCIRCS $VERSION"
-    local about="patchset for Version,$VERSION"
+    local about="patchset for Version, $VERSION"
     if [ -e $SCRIPTDIR/patches/ADCIRC/$VERSION/about.txt ]; then
       about=$(cat $SCRIPTDIR/patches/ADCIRC/$VERSION/about.txt | sed 's/\n//g')
     fi
     num=$(($num+1))
     printf "|%-2s) %-33s | %-66s |\n" $num $VERSION "$about"
   done
+    # final menu entry for custom directory
+    num=$(($num+1))
+    printf "|%-2s) %-33s | %-66s |\n" $num custom "select this option for custom directory"
   echo  "--"
   echo
-  ADCIRCS=($_ADCIRCS)
+  ADCIRCS=($_ADCIRCS custom)
   if [ "${1}" != "noexit" ]; then
     # exits on error if '1' is optionally passed, defaults to 0 (no error)
     exit ${1:-0} 
   fi
+  NUM_ADC=$num
 }
 
 if [ "${1}" = "supported" ]; then
@@ -101,9 +107,9 @@ if [ "$INTERACTIVE" == "yes" ]; then
   __ADCIRC_GIT_BRANCH=${ADCIRCS[0]} # current preferred default
   read -p "What supported 'version' of the ADCIRC source do you wish to build (by name or select 1-${NUM_ADC})? [$__ADCIRC_GIT_BRANCH] " _ADCIRC_GIT_BRANCH
 
-  #
-#   # Handles selection by number
-  #
+  #                                 #
+#   # Handles selection by number #   #
+  #                                 #
   if [ -n "$_ADCIRC_GIT_BRANCH" ]; then
     echo
     # check for number selection
@@ -115,7 +121,7 @@ if [ "$INTERACTIVE" == "yes" ]; then
         echo
         exit 1
       else
-        echo "(info) Selection: '$_ADCIRC_GIT_BRANCH'"
+        echo "${I} Selection: '$_ADCIRC_GIT_BRANCH'"
       fi
     fi
     # do not export, don't affect current environment after build
@@ -130,15 +136,45 @@ if [ "$INTERACTIVE" == "yes" ]; then
   PATCHSET_NAME=${ADCIRC_GIT_BRANCH}
   PATCHSET_DIR=${__ADCIRC_PATCHSET_BASE}/${PATCHSET_NAME}
   SWANDIR=
-  source $PATCHSET_DIR/info.sh
+  CUSTOM_SRC=
+  if [[ "$ADCIRC_GIT_BRANCH" != "custom" && -e $PATCHSET_DIR/info.sh ]]; then
+    source $PATCHSET_DIR/info.sh
+  elif [[ "$ADCIRC_GIT_BRANCH" == "custom" ]]; then
+    PATCHSET_DIR=
+    echo
+    read -p "What directory is the custom ADCIRC source code? " _CUSTOM_SRC
+    if [[ -z "$_CUSTOM_SRC" || ! -d $(readlink -f $_CUSTOM_SRC/work) ]]; then
+      echo "For 'custom' ADCIRC, a local source code directory is currently required. Please try again."
+      exit 1
+    fi
+    echo
+    CUSTOM_SRC=$(readlink -f $_CUSTOM_SRC)
+    echo "Found: '$CUSTOM_SRC'"
+    echo
+    # we need this later to get the profile name
+    _ADCIRC_GIT_BRANCH=${ADCIRC_GIT_BRANCH}
+    read -p "Custom profile name ['$_ADCIRC_GIT_BRANCH']? " _ADCIRC_GIT_BRANCH
+    ADCIRC_GIT_BRANCH=$_ADCIRC_GIT_BRANCH
+    PATCHSET_NAME=${ADCIRC_GIT_BRANCH} # will be 'custom'
+    if [[ -d $CUSTOM_SRC/swan ]]; then
+      SWANDIR=swan             # version  < 55
+    elif [[ -d $CUSTOM_SRC/thirdparty/swan ]]; then
+      SWANDIR=thirdparty/swan  # version >= 55
+    else
+      echo "FATAL ERROR: SWAN directory not found in '$CUSTOM_SRC', doesn't appear to be a valid ADCIRC source directory."
+      exit 1
+    fi
+  fi
 
   echo
-  # determine what to name the ADCIRC profile
+  # determine what to name the ADCIRC profile; if 'custom' $PATCHSET_NAME will be
+  # defined literally as the string "custom"
   if [ -n "$PATCHSET_NAME" ]; then
     __ADCIRC_PROFILE_NAME=${PATCHSET_NAME}-${ADCIRC_COMPILER}-${ASGS_MACHINE_NAME}
   else
     __ADCIRC_PROFILE_NAME=${ADCIRC_GIT_BRANCH}-${ADCIRC_COMPILER}-${ASGS_MACHINE_NAME}
-  fi
+  fi 
+
   read -p "What would you like to name this ADCIRC build profile? [$__ADCIRC_PROFILE_NAME] " _ADCIRC_PROFILE_NAME
   if [ -n "$_ADCIRC_PROFILE_NAME" ]; then
     ADCIRC_PROFILE_NAME=$_ADCIRC_PROFILE_NAME
@@ -156,6 +192,21 @@ if [ "$INTERACTIVE" == "yes" ]; then
     ADCIRCBASE=$__ADCIRCBASE
   fi
   echo
+fi
+
+if [[ -d "${ADCIRCBASE}" ]]; then
+  _delete=N
+  echo "$W '$ADCIRCBASE' exists!"
+  read -p "$W delete and proceed y/N? [$_delete] " delete
+  echo
+  if [ -z "$delete" ]; then
+    delete=$_delete
+  fi
+  if [[ "${delete,,}" == "n" ]]; then
+    exit 1
+  fi
+  echo " ... deleting '$ADCIRCBASE'"
+  rm -rf $ADCIRCBASE
 fi
 
 ADCIRCDIR=${ADCIRCBASE}/work
@@ -190,38 +241,53 @@ ADCSWAN_MAKE_CMD="make $ADCSWAN_BINS compiler=${ADCIRC_COMPILER} MACHINENAME=${A
 SWAN_UTIL_BINS="unhcat.exe"
 SWAN_UTIL_BINS_MAKE_CMD="make unhcat compiler=${ADCIRC_COMPILER} MACHINENAME=${ASGS_MACHINE_NAME}"
 
-if [ ! -d ${ADCIRCBASE} ]; then
-  if [ "$INTERACTIVE" == "yes" ]; then
-    _answer=yes
-    read -p "Create directory, '$ADCIRCBASE'? [$_answer] " answer
-    if [ -z "$answer" ]; then
-      answer=$_answer
+# git repo wrangling if not copying from a local filesystem
+#TODO: put all this in function
+if [[ -d "${CUSTOM_SRC}" ]]; then                     # handle custom filesystem based source, no patches
+  # copy across local file system
+  mkdir -p $ADCIRCBASE
+  echo " ... copying from from '$CUSTOM_SRC' to '$ADCIRCBASE'"
+  cp -rf $CUSTOM_SRC/* $ADCIRCBASE
+  # clean up destination
+  echo " ... cleaning up cruft from '$ADCIRCBASE'"
+  rm -rf $ADCIRCBASE/.git 2> /dev/null
+  pushd $ADCIRCBASE
+  make clobber
+  popd
+elif [[ -z "${CUSTOM_SRC}" ]]; then                   # handle git-based menu item with patches
+  if [[ ! -d ${ADCIRCBASE} ]]; then
+    if [ "$INTERACTIVE" == "yes" ]; then
+      _answer=yes
+      read -p "Create directory, '$ADCIRCBASE'? [$_answer] " answer
+      if [ -z "$answer" ]; then
+        answer=$_answer
+      fi
+      if [ "$answer" != 'yes' ]; then
+        echo '(fatal) no directory was created. Exiting install.'
+        exit
+      fi
+      echo
     fi
-    if [ "$answer" != 'yes' ]; then
-      echo '(fatal) no directory was created. Exiting install.'
-      exit
-    fi
+    mkdir -p ${ADCIRCBASE} 2> /dev/null
+  else
+    echo Found directory, ${ADCIRCBASE}
     echo
   fi
-  mkdir -p ${ADCIRCBASE} 2> /dev/null
-else
-  echo Found directory, ${ADCIRCBASE}
-  echo
-fi
-if [ ! -d ${ADCIRCBASE}/.git ]; then
-  if [ "$INTERACTIVE" == "yes" ]; then
-    _answer=yes
-    read -p "Download ADCIRC git repository from GitHub? [$_answer] " answer
-    if [ -z "$answer" ]; then
-      answer=$_answer
+  if [ ! -d ${ADCIRCBASE}/.git ]; then
+    if [ "$INTERACTIVE" == "yes" ]; then
+      _answer=yes
+      read -p "Download ADCIRC git repository from GitHub? [$_answer] " answer
+      if [ -z "$answer" ]; then
+        answer=$_answer
+      fi
+      if [ "$answer" != 'no' ]; then
+        echo
+        git clone ${ADCIRC_GIT_URL}/${ADCIRC_GIT_REPO}.git ${ADCIRCBASE}
+      fi
     fi
-    if [ "$answer" != 'no' ]; then
-      echo
-      git clone ${ADCIRC_GIT_URL}/${ADCIRC_GIT_REPO}.git ${ADCIRCBASE}
-    fi
+  else
+    echo "$ADCIRCBASE appears to already contain a git repository."
   fi
-else
-  echo "$ADCIRCBASE appears to already contain a git repository."
 fi
 
 # current branch management is naive and assumes that the branch
@@ -297,7 +363,7 @@ function dumpJSON()
       _CC=$(which gcc)
     ;;
     *)
-      echo '(warn) unknown compiler is unsupported...; defaulting to info for "intel"'
+      echo '${W} unknown compiler is unsupported...; defaulting to "intel"'
     esac 
     local _FC_VERSION=$($_FC --version | head -n 1) 
     local _CC_VERSION=$($_CC --version | head -n 1)
@@ -348,6 +414,7 @@ $patchJSON
     "env.adcirc.build.ADCIRCBASE"        : "$ADCIRCBASE",
     "env.adcirc.build.ADCIRCDIR"         : "$ADCIRCDIR",
     "env.adcirc.build.SWANDIR"           : "$SWANDIR",
+    "env.adcirc.build.CUSTOM_SRC"        : "${CUSTOM_SRC:-0}", 
     "env.adcirc.build.ADCIRC_COMPILER"   : "$ADCIRC_COMPILER",
     "env.adcirc.build.ADCIRC_GIT_BRANCH" : "$ADCIRC_GIT_BRANCH",
     "env.adcirc.build.ADCIRC_GIT_URL"    : "$ADCIRC_GIT_URL",
@@ -411,16 +478,24 @@ META
 #
 BUILDSCRIPT="${ADCIRCBASE}/asgs-build.sh"
 ADCIRC_BUILD_INFO=${ADCIRCBASE}/adcirc.bin.buildinfo.json
-if [ -n "${PATCHSET_DIR}" ]; then
+
+# NOTE: Currently, patches are only available when the patchset
+# directory is present in $SCRIPTDIR/patches/ADCIRC; they are
+# not applied what CUSTOM_SRC is defined (i.e., pointing to a
+# custom source that is presumably already to build without patching)
+if [[ -z "${CUSTOM_SRC}" && -n "${PATCHSET_DIR}" ]]; then
   if [ -e "${BUILDSCRIPT}" ]; then
     echo "(info) patches already applied, skipping ..."
     ALREADYPATCHED=1
   else
-    if [ ! -d "${PATCHSET_DIR}" ]; then
+    if [[ ! -d "${PATCHSET_DIR}" && -z "${CUSTOM_SRC}" ]]; then
       echo "(fatal) patch set directory not found. Exiting."
       exit 1
     fi
     echo
+    #
+    # P A T C H E S  A P P L I E D  H E R E
+    #
     echo applying patches from $PATCHSET_DIR ...
     # apply from perspective of $ADCIRCBASE, since it's possible we could also
     # be patching in a third party directory
@@ -501,6 +576,34 @@ mkdir -p $ADCIRC_META_DIR 2> /dev/null
 dumpMETA "$ADCIRC_META_DIR/$ADCIRC_PROFILE_NAME"
 
 if [ "$INTERACTIVE" == "yes" ]; then
+  echo
+  echo '                    .?MMMMMMM8$@m-(".-.'
+  echo '                 (MMMMMMMMMMMMMMe(%e9ODA#%eRwC1%%?!-";'
+  echo '                MMMMMADCIRCMMMMM*%JOMMADCIRCMMMM8M0DC?*%4?".'
+  echo '              .9MMMMMMMMMMMMMMMwe2#MMMMMMRC41%J#M&DC1D8&wM@*M&'
+  echo '              MMMADCIRCMMMMM0@R9eemMMM#0##M9m**i(%???*i(|1#MRD2'
+  echo '             MMMMMMMMMMM@$449w2C!J%?C%"";"eCw$"|m==||;-`M.'
+  echo '           .MMADCIRCMMDO*i(((||(ii?*1?*%i"=(?mR  1%?(("%!'
+  echo '           mM@MM92e! ;"i"?ii(ei;""""";";-(??.'
+  echo '          %MA!!?;"%"="i""mi -1"""|""=;"""`&('
+  echo '          .(4?"(= ;;"""*9w|.-||(i%%|;` ;;.; '
+  echo '           *eJ;`%("((|i99C|.=|C=!1e;"w......'
+  echo '           0m*"1|;"!*(&9me .-1       M .`..R'
+  echo '           29*"M      -&C(..";       "i . i%'
+  echo '           #C!%m      MRD"...J        M.;(|.'
+  echo '           @81!9     i&&2;...J=       1;!eiM'
+  echo '           99*C8     9!"=  `.(%       $A&2"92'
+  echo '           w=-(?     M%=`.`.e(        AMM*%!.'
+  echo '          CM("A      OJ%. .!e         #MMO1w%'
+  echo '          CMA"M.   .MMM%-; *.         (MMMR0M'
+  echo '         %MMO!wD4 -MMM@%"|"M.        1MMMM8&DJ'
+  echo '         8O1DMMM0w"(!%(*1%"M*       .MM%?AOMMM.'
+  echo '         R#MMMMMM!24mO91!("=J.      *MMwADCIRCMM'
+  echo '     =C@M0MM@Ae2MADCIRCMA1%"%J4|    %MMMMMMM0@&M?"'
+  echo '   (*M@MMR&&&2C#@#R&&&OC(" .&1= ***MMMM#A8&AA1(=('
+  echo '  ******%(MMMMM@M#OwmJw4A&&i.="2MMM8OwRwCCC1JmD&&$MD'
+  echo
+  echo S U C C E S S ! 
   echo
   echo ADCIRC has been build and the ADCIRC profile registered in asgsh.
   echo To load this profile, at the asgsh prompt, enter:


### PR DESCRIPTION
Issue-748: This will allow users with ADCIRC source somewhere on their
ASGS host machine to build and register ADCIRC via `build adcirc`, by
selecting the "custom" option and answering the questions in the interactive
mode that follows. Upon successful compilation, this ADCIRC is available
like all others via "load adcirc" and can be seen along with the others
via "list adcirc". Patches are not supported at this time.

Resolves #748.