### PR TITLE
Added "fetch" command.

### DIFF
--- a/bin/fetch
+++ b/bin/fetch
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+if [ -z "$_ASGSH_PID" ]; then
+  echo "This script is meant to run inside of the ASGS Shell Environment, asgsh."
+  exit 1;
+fi
+
+# this is just a starter, the above stuff might go into a shell "library" at some
+# point
+
+ITEM=${1}
+I="(info)"
+W="(!! warning)"
+
+case "${ITEM}" in
+  all)
+    fetch configs
+    fetch cera-asgs
+    fetch docs
+    fetch storm-archive
+    fetch adcirc-testsuite
+    ;;
+  configs)
+    mkdir $SCRIPTDIR/git 2> /dev/null
+    pushd $SCRIPTDIR/git  > /dev/null  2>&1
+    if [ -d ./asgs-configs ]; then
+      echo "${W} $SCRIPTDIR/git/asgs-configs exists ... nothing done"
+      popd > /dev/null 2>&1 
+      exit 1
+    fi
+    git clone git@github.com:StormSurgeLive/asgs-configs.git $SCRIPTDIR/git/asgs-configs
+    popd > /dev/null 2>&1 
+    ;;
+  docs)
+    mkdir $SCRIPTDIR/git 2> /dev/null
+    pushd $SCRIPTDIR/git  > /dev/null  2>&1
+    if [ -d ./asgs.wiki ]; then
+      echo "${W} $SCRIPTDIR/git/asgs.wiki exists ... nothing done"
+      popd > /dev/null 2>&1 
+      exit 1
+    fi
+    git clone git@github.com:StormSurgeLive/asgs.wiki.git $SCRIPTDIR/git/asgs.wiki
+    popd > /dev/null 2>&1 
+    ;;
+  cera-asgs)
+    mkdir $SCRIPTDIR/git 2> /dev/null
+    pushd $SCRIPTDIR/git  > /dev/null  2>&1
+    if [ -d ./cera-asgs-environment ]; then
+      echo "${W} $SCRIPTDIR/git/cera-asgs-environment exists ... nothing done"
+      popd > /dev/null 2>&1 
+      exit 1
+    fi
+    git clone git@github.com:CERA-GROUP/cera-asgs-environment.git $SCRIPTDIR/git/cera-asgs-environment
+    popd > /dev/null 2>&1 
+    ;;
+  storm-archive)
+    mkdir $SCRIPTDIR/git 2> /dev/null
+    pushd $SCRIPTDIR/git  > /dev/null  2>&1
+    if [ -d ./storm-archive ]; then
+      echo "${W} $SCRIPTDIR/git/storm-archive exists ... nothing done"
+      popd > /dev/null 2>&1 
+      exit 1
+    fi
+    git clone git@github.com:StormSurgeLive/storm-archive.git $SCRIPTDIR/git/storm-archive
+    popd > /dev/null 2>&1 
+    ;;
+  adcirc-testsuite)
+    mkdir $SCRIPTDIR/git 2> /dev/null
+    pushd $SCRIPTDIR/git  > /dev/null  2>&1
+    if [ -d ./adcirc-testsuite ]; then
+      echo "${W} $SCRIPTDIR/git/adcirc-testsuite exists ... nothing done"
+      popd > /dev/null 2>&1 
+      exit 1
+    fi
+    git clone git@github.com:adcirc/adcirc-testsuite.git $SCRIPTDIR/git/adcirc-testsuite
+    popd > /dev/null 2>&1 
+    ;;
+  *)
+    cat << EOF
+
+'$ITEM' not supported via ASGS' "fetch" command
+
+ Supported:
+  * configs          - git clones ASGS asgs-config           (public)
+  * cera-asgs        - git clones CERA cera-asgs-environment (private)
+  * docs             - git clones ASGS asgs.wiki             (public)
+  * storm-archive    - git clones ASGS storm-archive         (public)
+  * adcirc-testsuite - git clones ADCIRC's test-suite        (public)
+  * all              - attempts all of the above
+
+ Example, checkout ASGS configs into, "$SCRIPTDIR/git/asgs-configs":
+
+ asgs> fetch configs
+ 
+Note: Create a GH issue if there is something missing here that
+you think should be added.
+EOF
+    exit 1
+    ;;
+esac

--- a/cloud/general/DOT-asgs-brew.sh
+++ b/cloud/general/DOT-asgs-brew.sh
@@ -67,6 +67,7 @@ help() {
   echo "           profile <name>      - directly edit the named ASGSH Shell profile"
   echo "           statefile           - open up STATEFILE (if set) in EDITOR for easier forensics"
   echo "           syslog              - open up SYSLOG (if set) in EDITOR for easier forensics"
+  echo "   fetch   <thing>             - tool for fetching supported external resources, e.g., git repos; 'fetch' with no parameter will list what is supported"
   echo "   goto    <param>             - change CWD to a supported directory. Type 'goto options' to see the currently supported options"
   echo "   guess   platform            - attempts to guess the current platform as supported by platforms.sh (e.g., frontera, supermic, etc)"
   echo "   inspect <option>            - alias to 'edit' for better semantics; e.g., 'inspect syslog' or 'inspect statefile'"


### PR DESCRIPTION
Issue 737: 'fetch' command allows for the easy "getting" (via git checkout
or some other means) of eternal ASGS resources.

Supports:

  asgs-configs
  asgs.wiki
  cera-asgs
  storm-archive
  adcirc-testsuite

Resolves #737.