### PR TITLE
Added way to prepend a directory to the OpenDAP path formation.

### DIFF
--- a/output/opendap_post2.sh
+++ b/output/opendap_post2.sh
@@ -225,6 +225,7 @@ for server in ${SERVERS[*]}; do
    DOWNLOADPREFIX=${properties["post.opendap.${server}.downloadprefix"]}
    CATALOGPREFIX=${properties["post.opendap.${server}.catalogprefix"]}
    OPENDAPBASEDIR=${properties["post.opendap.${server}.opendapbasedir"]}
+   OPENDAPADDROOT=${properties["post.opendap.addroot"]}
    #
    #--------------------------------------------------------------------
    #  O P E N  D A P    P A T H   F O R M A T I O N
@@ -235,7 +236,11 @@ for server in ${SERVERS[*]}; do
       # for NAM, the "advisory number" is actually the cycle time
       YEAR=${properties["forcing.nwp.year"]}
       NWPMODEL=${properties["forcing.nwp.model"]}
-      STORMNAMEPATH=$YEAR/$NWPMODEL
+      if [ -n "${OPENDAPADDROOT}" ]; then
+        STORMNAMEPATH=$OPENDAPADDROOT/$YEAR/$NWPMODEL
+      else
+        STORMNAMEPATH=$YEAR/$NWPMODEL
+      fi
    fi
    if [[ $TROPICALCYCLONE = on ]]; then
       YEAR=${properties["forcing.tropicalcyclone.year"]}
@@ -243,17 +248,30 @@ for server in ${SERVERS[*]}; do
       STORMNUMBER=${properties["forcing.tropicalcyclone.stormnumber"]}
       STORMNAMELC=`echo $STORMNAME | tr '[:upper:]' '[:lower:]'`
       basin="al" # FIXME: write/read a property instead of hardcoding the atlantic basin
-      STORMNAMEPATH=$YEAR/$basin$STORMNUMBER
-      ALTSTORMNAMEPATH=$YEAR/$STORMNAMELC  # symbolic link with name
+      if [ -n "${OPENDAPADDROOT}" ]; then
+        STORMNAMEPATH=$OPENDAPADDROOT/$YEAR/$basin$STORMNUMBER
+        ALTSTORMNAMEPATH=$OPENDAPADDROOT/$YEAR/$STORMNAMELC  # symbolic link with name
+      else
+        STORMNAMEPATH=$YEAR/$basin$STORMNUMBER
+        ALTSTORMNAMEPATH=$YEAR/$STORMNAMELC  # symbolic link with name
+      fi
    fi
    if [[ $SCENARIO = "hindcast" ]]; then
       YEAR=${COLDSTARTDATE:0:4}
-      STORMNAMEPATH=$YEAR/initialize
+      if [ -n "${OPENDAPADDROOT}" ]; then
+        STORMNAMEPATH=$OPENDAPADDROOT/$YEAR/initialize
+      else
+        STORMNAMEPATH=$YEAR/initialize
+      fi
    fi
    # form path to results on tds based on type of forcing or name of storm
    if [[ $SCENARIO == "asgs.instance.status" ]]; then
       YEAR=${COLDSTARTDATE:0:4}
-      STORMNAMEPATH=$YEAR/status
+      if [ -n "${OPENDAPADDROOT}" ]; then
+        STORMNAMEPATH=$OPENDAPADDROOT/$YEAR/status
+      else
+        STORMNAMEPATH=$YEAR/status
+      fi
       OPENDAPSUFFIX=$HPCENV/$INSTANCENAME
       # update the url properties in the status json files before posting them
       # and save the url for keeping track of the previous url

--- a/variables_init.sh
+++ b/variables_init.sh
@@ -178,4 +178,5 @@ variables_init()
 
    SCENARIO="null"
    SCENARIODIR="null"
+   OPENDAPADDROOT=""
 }

--- a/writeProperties.sh
+++ b/writeProperties.sh
@@ -114,6 +114,9 @@ writeProperties()
    echo "post.opendap.tds : ( ${TDS[@]} )" >> $STORMDIR_RUN_PROPERTIES
    echo "post.opendap.target : $TARGET" >> $STORMDIR_RUN_PROPERTIES
    echo "post.file.sshkey : $SSHKEY" >> $STORMDIR_RUN_PROPERTIES
+   if [ -n "$OPENDAPADDROOT" ]; then
+     echo "post.opendap.addroot : ${OPENDAPADDROOT}" >> $STORMDIR_RUN_PROPERTIES
+   fi
    # archiving
    echo "archive.executable.archive : $ARCHIVE" >> $STORMDIR_RUN_PROPERTIES
    echo "archive.path.archivebase : $ARCHIVEBASE" >> $STORMDIR_RUN_PROPERTIES


### PR DESCRIPTION
Issue 931: Defining OPENDAPADDROOT in an ASGS configuration file will
cause an additional directory to be prepended to the data path
created and used as the upload target, in output/opendap_post2.sh.

For example, adding the following to the ASGS config fle,

```
  OPENDAPADDROOT=replay-test
```

Will ultimately make the files accessible in a url that is rooted
at 'replay-test', e.g.,

```
  http://chg-1.oden.tacc.utexas.edu/thredds/catalog/asgs/replay-test/2022/al05/11/TX2008/ls6.tacc.utexas.edu/TX2008-replay-ls6/nhcConsensus/catalog.html
                                                         ^^^^^^^^^^^^
```

If not set, the URL would normally look as follows,

```
  http://chg-1.oden.tacc.utexas.edu/thredds/catalog/asgs/2022/al05/11/TX2008/ls6.tacc.utexas.edu/TX2008-replay-ls6/nhcConsensus/catalog.html
                                                         ^^^^^^^^^^^^
```
Resolves #931.