### PR TITLE
Local mesh support

### DIFF
--- a/bin/list
+++ b/bin/list
@@ -40,6 +40,14 @@ _list() {
         printf "% 2d. %s\n" $LISTNUM $m
         LISTNUM=$(($LISTNUM+1))
       done
+      # list locally defined meshes if they exist
+      local LOCAL_MESH_DEFAULTS="${ASGS_LOCAL_DIR}/config/mesh_defaults.sh"
+      if [[ -n "$ASGS_LOCAL_DIR" && -e "$LOCAL_MESH_DEFAULTS" ]]; then
+        for m in $(cat $LOCAL_MESH_DEFAULTS | grep '")' | sed 's/[")]//g' | awk '{print $1}'); do
+          printf "% 2d. %s (** locally defined)\n" $LISTNUM $m
+          LISTNUM=$(($LISTNUM+1))
+        done
+      fi
       ;;
     platforms)
       cat $ASGS_PLATFORMS | egrep '^init_' | sed 's/init_//g' | sed 's/()//g' | awk '{print "- " $1}'


### PR DESCRIPTION
In principle this works, assuming `$ASGS_LOCAL_DIR` is defined; this is currently accomplished by:

1. having some local asset directory available with `path/to/local-asgs-assets/configs/mesh_defaults` defining meshes
2. mesh assets available per definitions in `path/to/local-asgs-assets/configs/mesh_defaults`
3. this change, assuming `$ASGS_LOCAL_DIR` is configured properly works in `asgsh`'s `list meshes`

Set up for `$ASGS_LOCAL_DIR`, currently requires re-running `./init-asgs.sh` with the `-p path/to/local-asgs-assets` set even if the platform is officially supported. This is because `./update-asgs` and `./asgsh` are where `$ASGS_LOCAL_DIR` are persisted. We need a consistent way to register a local assets directory.

In order to test, we need a test `path/to/local-asgs-assets` directory with a proper `./configs/mesh_defaults.sh` and mesh assets in `./input/meshes/localMeshName/`.