### PR TITLE
Corrected typos in fort.15 template for TXLA2022a

### DIFF
--- a/bin/get-coldstart-date
+++ b/bin/get-coldstart-date
@@ -6,13 +6,39 @@
 # Usage, in an ASGS config script:
 #
 #   HINDCASTLENGTH=30
+#   # finds HINDCASTLENGTH or sets default
+#   COLDSTARTDATE=$(get-coldstart-date)
+#
+#   or
+#
+#   HINDCASTLENGTH=30
+#   # explicitly passed HINDCASTLENGTH
 #   COLDSTARTDATE=$(get-coldstart-date ${HINDCASTLENGTH})
+
+#   or
+#
+#   HINDCASTLENGTH=30
+#   HINDCASTENDDATE=2020103000
+#   # explicitly passed HINDCASTLENGTH and HINDCQSTENDDATE (order matters)
+#   COLDSTARTDATE=$(get-coldstart-date)
+#
+#   or
+#
+#   HINDCASTLENGTH=30
+#   HINDCASTENDDATE=2020103000
+#   # explicitly passed HINDCASTLENGTH and HINDCQSTENDDATE (order matters)
+#   COLDSTARTDATE=$(get-coldstart-date ${HINDCASTLENGTH} ${HINDCASTENDDATE})
 #
 
-HINDCASTLENGTH=${1:-30}
-defaultHINDCASTENDDATE=$(date +%Y%m%d)  # e.g., 20210505
-HINDCASTENDDATE=${2:-$defaultHINDCASTENDDATE} 
+defaultHINDCASTLENGTH=${HINDCASTLENGTH:-"30"}
+HINDCASTLENGTH=${1:-$defaultHINDCASTLENGTH}
+
+defaultHINDCASTENDDATE=${HINDCASTENDDATE:-$(date +%Y%m%d)}
+HINDCASTENDDATE=${2:-$defaultHINDCASTENDDATE}
+
 COLDSTARTDATE=$(date --date="${HINDCASTENDDATE} -${HINDCASTLENGTH} days" +%Y%m%d%H)
-echo -n $COLDSTARTDATE
+
+# print to STDOUT, no new line
+printf "%d" $COLDSTARTDATE
 
 exit 0

--- a/input/meshes/TXLA22a/TXLA22a.15
+++ b/input/meshes/TXLA22a/TXLA22a.15
@@ -4,7 +4,7 @@ Run_001
 0        	 ! NABOUT 
 300        	 ! NSCREEN 
 0        	 ! IHOT 
-20         	 ! ICS 
+2          	 ! ICS
 511112          	 ! IM 
 1            	 ! NOLIBF 
 2            	 ! NOLIFA 

--- a/input/meshes/TXLA22a/TXLA22a_fort.15.template
+++ b/input/meshes/TXLA22a/TXLA22a_fort.15.template
@@ -4,7 +4,7 @@ ASGS %StormName%
 0        	 ! NABOUT 
 %NSCREEN%        	 ! NSCREEN 
 %IHOT%        	 ! IHOT 
-20         	 ! ICS 
+2         	 ! ICS
 511112          	 ! IM 
 1            	 ! NOLIBF 
 2            	 ! NOLIFA 


### PR DESCRIPTION
    Corrected typos.
    
    Issue 1016: Found and fixed 2 typos in the fort.15 templates;
    `ICS` was set to 20, which is invalid (I think). Changed it to
    the value of 2 (lat/lon), which worked for adcpre.
    
    Accidentally contains updates to bin/get-coldstart-day - but these
    can be separated into separate commits at merge time.
    
    Resolves #1016.
    Resolves #1013.
