### PR TITLE
Fixing `load adcirc` due to lost of `ADCIRCDIR` (put it back).

### DIFF
--- a/bin/init-adcirc.sh
+++ b/bin/init-adcirc.sh
@@ -215,7 +215,7 @@ if [[ -d "${ADCIRCBASE}" ]]; then
 fi
 
 # some variables based on ADCIRCBASE that we can define now
-ADCIRC_WORK_DIR=${ADCIRCBASE}/work
+ADCIRCDIR=${ADCIRCBASE}/work
 BUILDSCRIPT="${ADCIRCBASE}/asgs-build.sh"
 ADCIRC_BUILD_INFO=${ADCIRCBASE}/adcirc.bin.buildinfo.json
 
@@ -233,7 +233,7 @@ case "${ADCIRC_SRC_TYPE}" in
     # clean up destination
     echo " ... cleaning up cruft from '$ADCIRCBASE'"
     rm -rf $ADCIRCBASE/.git 2> /dev/null
-    pushd $ADCIRC_WORK_DIR
+    pushd $ADCIRCDIR
     make clobber
     popd
     ;;
@@ -406,7 +406,7 @@ $patchJSON
     "env.adcirc.build.ASGS_MACHINE_NAME"  : "$ASGS_MACHINE_NAME",
     "env.adcirc.build.NETCDFHOME"         : "$NETCDFHOME",
     "env.adcirc.build.ADCIRCBASE"         : "$ADCIRCBASE",
-    "env.adcirc.build.ADCIRC_WORK_DIR"    : "$ADCIRC_WORK_DIR",
+    "env.adcirc.build.ADCIRCDIR"    : "$ADCIRCDIR",
     "env.adcirc.build.SWANDIR"            : "$SWANDIR",
     "env.adcirc.build.CUSTOM_SRC"         : "${CUSTOM_SRC:-0}", 
     "env.adcirc.build.ADCIRC_COMPILER"    : "${ADCIRC_COMPILER:-0}",
@@ -453,7 +453,7 @@ export ASGS_HOME='$ASGS_HOME'
 export ASGS_MACHINE_NAME='$ASGS_MACHINE_NAME'
 export NETCDFHOME='$NETCDFHOME'
 export ADCIRCBASE='$ADCIRCBASE'
-export ADCIRC_WORK_DIR='$ADCIRC_WORK_DIR'
+export ADCIRCDIR='$ADCIRCDIR'
 export SWANDIR='$SWANDIR'
 export ADCIRC_COMPILER='$ADCIRC_COMPILER'
 export ADCIRC_BUILD_INFO='$ADCIRC_BUILD_INFO'
@@ -546,10 +546,10 @@ case "${ADCIRC_SRC_TYPE}" in
 esac
 
 echo
-echo "About to build ADCIRC in $ADCIRC_WORK_DIR with the following command:"
+echo "About to build ADCIRC in $ADCIRCDIR with the following command:"
 echo "cd $SWANDIR && \\"                 >> ${BUILDSCRIPT}
 echo "   $SWAN_UTIL_BINS_MAKE_CMD && \\" >> ${BUILDSCRIPT}
-echo "cd $ADCIRC_WORK_DIR && \\"         >> ${BUILDSCRIPT}
+echo "cd $ADCIRCDIR && \\"               >> ${BUILDSCRIPT}
 echo "   $ADCIRC_MAKE_CMD && \\"         >> ${BUILDSCRIPT}
 echo "   $ADCSWAN_MAKE_CMD"              >> ${BUILDSCRIPT}
 


### PR DESCRIPTION
Issue 1038: The changes in #1004 took renamed ADCIRCDIR to ADCIRC_WORK_DIR, but this had effects outside of `bin/init-adcirc.sh` (which does the building and contains the wizard). This should not have been done since `ADCIRCDIR` is used externally, e.g., in `./asgs_main.sh`; not to mention the most obvious place that spawned this case, in `load adcirc`. So rather than changing `ADCIRCDIR` everwhere, it was restored. `ADCIRCDIR` preceeded `bin/init-adcirc.sh`.

Resolves #1038.