### PR TITLE
Add `scp://`, `ssh://` transports

### DIFF
--- a/asgs_main.sh
+++ b/asgs_main.sh
@@ -1806,7 +1806,7 @@ hotstartBase=fort.${LUN}
 hotstartSuffix=.nc
 hotstartPath=${LASTSUBDIR}/nowcast # only for reading from local filesystem
 hotstartURL=null
-hotstartDownloadExecutable="curl"
+hotstartDownloadExecutable="curl --insecure"
 hotstartDownloadRedirect="--output"
 if [[ $HOTORCOLD = hotstart ]]; then
    consoleMessage "$I Acquiring hotstart file."
@@ -1823,6 +1823,8 @@ if [[ $HOTORCOLD = hotstart ]]; then
       if [[ $LASTSUBDIR =~ "scp://" ]]; then
          hotstartDownloadExecutable="scp"
          hotstartDownloadRedirect=""
+         hotstartURL=${hotstartURL:6}     # remove leading scp://
+         hotstartURL=${hotstartURL/\//:}  # replace / between host and path with :
       fi
    else
       # we are reading the hotstart file from the local filesystem, determine

--- a/asgs_main.sh
+++ b/asgs_main.sh
@@ -1765,6 +1765,16 @@ consoleMessage "$I CONFIG: '${CONFIG}'"
 consoleMessage "$I Verifying that required files and directories actually exist."
 #
 checkDirExistence $INPUTDIR "directory for input files"
+
+# hook to run a script to get large files or do other
+# out of band things to get files; execution happens in $INPUTDIR;
+# prepending $INPUTDIR is on purpose, the file *must* exist in INPUTDIR
+if [ -x "${INPUTDIR}/${INITINPUT}" ]; then
+  pushd $INPUTDIR
+  ./$INITINPUT
+  popd
+fi
+
 checkDirExistence $OUTPUTDIR "directory for post processing scripts"
 #
 if [[ $QUEUESYS = serial ]]; then


### PR DESCRIPTION
resolves #715 not tested yet

(edited by @wwlwpd below)

We discussed on 4/9/24, updating this PR:

- [x] support both `scp://` and `ssh://` due to the upstream desire to deprecated `scp`, but also user preference (it is okay if `ssh://` uses `scp` underneath
- [x] ~~if it looks like a file (i.e., doesn't have `http://`, `https://`, or `ssh://`), look for the standard `HOST:/path/to/file`; this can be done easily by splitting on the `:`, with `awk -F: '{print $1}'` and `awk -F '{print $2}'`.~~ - I suggest we strike this
- [x] These things to do will round out this support nicely. In the future, other protocols may become important (e.g., `s3://`, etc); so we definitely want to be able to have a clear place to support them and a consistent way to support them across the ASGS toolset.
- [x] add `INITINPUT` variable that will run a specified script, if defined, at input fetch time
- [x] update CERA mesh_defaults.sh with `INITINPUT` ([see](https://github.com/CERA-GROUP/asgs-local-assets/pull/3))
- [x] update docs ([wiki](https://github.com/StormSurgeLive/asgs/wiki/Adding-a-New-Mesh), in mesh_default.sh files)