### PR TITLE
Adding explictly nodalattr.o and nodalattr.mod allows for successful …

### DIFF
--- a/util/input/mesh/makefile
+++ b/util/input/mesh/makefile
@@ -83,8 +83,8 @@ ifeq ($(NETCDF4_COMPRESSION),enable)
 endif
 #
 #
-OBJ := adcmesh.o asgsio.o logging.o
-MODS := adcmesh.mod asgsio.mod logging.mod
+OBJ := adcmesh.o asgsio.o logging.o nodalattr.o
+MODS := adcmesh.mod asgsio.mod logging.mod nodalattr.mod
 #
 # targets
 all : boundaryFinder


### PR DESCRIPTION
…linking on QB.

Issue 1119: Added explicitly the required libraries during the linking phase, seems everything was correct except this final step. It's a mystery why this was only being exposed on queenbee2 (LONI), but this changes fixes it.

Resolves #1119.