### PR TITLE
Added support for ASGSADMIN_ID.

### DIFF
--- a/bin/asgs-sendmail
+++ b/bin/asgs-sendmail
@@ -103,9 +103,9 @@ sub run {
 
     # check for subjects > 78 characters, which is the max line length according to the
     # email RFC
-    if ( length $subject > 99 ) {
-        warn qq{(asgs-sendmail) WARNING: Length of --subject is > 99 characters, truncating ...\n};
-        $subject = substr $subject, 0, 99;
+    if ( length $subject > 120 ) {
+        warn qq{(asgs-sendmail) WARNING: Length of --subject is > 120 characters, truncating ...\n};
+        $subject = substr $subject, 0, 120;
     }
 
     my $message = Email::Simple->create(
@@ -205,7 +205,7 @@ not defined, then it default to C<$HOME/mail.log>.
 
 Defines subject thread. There is a default, but it's meaningless.
 
-If the subject test is > 99 characters in length, the script issues a warning
+If the subject test is > 120 characters in length, the script issues a warning
 and truncates the subject text. This limit was determined through empiracle
 testing of what provided for the most reliable email delivery.
 

--- a/config/config_defaults.sh
+++ b/config/config_defaults.sh
@@ -76,3 +76,4 @@ THIS=$(basename -- $0)
    # to their email address in their ~/.asgsh_profile files
    # on each platform
    ASGSADMIN=null
+   ASGSADMIN_ID=null

--- a/platforms.sh
+++ b/platforms.sh
@@ -332,6 +332,7 @@ writeTDSProperties()
    case $SERVER in
    "renci_tds")
       THREDDSHOST=tds.renci.org # WWW hostname for emailed links
+      OPENDAPINDEX=catalog.html
       OPENDAPHOST=renci_tds     # alias in $HOME/.ssh/config
       OPENDAPPORT=":80"
       OPENDAPPROTOCOL="http"
@@ -343,6 +344,7 @@ writeTDSProperties()
    # THREDDS Data Server (TDS, i.e., OPeNDAP server) at LSU
    "lsu_tds")
       THREDDSHOST=fortytwo.cct.lsu.edu
+      OPENDAPINDEX=""           # this is just a directory listing, no index file
       OPENDAPHOST=lsu_tds
       OPENDAPPORT=":443"
       OPENDAPPROTOCOL="https"
@@ -368,6 +370,7 @@ writeTDSProperties()
    # Advanced Computing Center (TACC)
    "tacc_tds")
       THREDDSHOST=adcircvis.tacc.utexas.edu # WWW hostname for emailed links
+      OPENDAPINDEX=catalog.html
       OPENDAPHOST=tacc_tds                  # alias in $HOME/.ssh/config
       OPENDAPPORT=":8080"
       OPENDAPPROTOCOL="http"
@@ -405,6 +408,7 @@ writeTDSProperties()
    echo "post.opendap.${SERVER}.downloadprefix : $OPENDAPPROTOCOL://$THREDDSHOST$OPENDAPPORT/thredds/fileServer$DOWNLOADPREFIX" >> $RUNPROPERTIES
    echo "post.opendap.${SERVER}.catalogprefix : $OPENDAPPROTOCOL://$THREDDSHOST$OPENDAPPORT/thredds/catalog$CATALOGPREFIX" >> $RUNPROPERTIES
    echo "post.opendap.${SERVER}.opendapbasedir : $OPENDAPBASEDIR" >> $RUNPROPERTIES
+   echo "post.opendap.${SERVER}.opendapindex : $OPENDAPINDEX" >> $RUNPROPERTIES
    # if the Operator has an asgs-global.conf file, assume that a perl mail client capability is
    # set up and ready to use
    echo "notification.opendap.email.opendapmailserver : aws" >> $RUNPROPERTIES

--- a/ssh-servers/tacc_tds3.sh
+++ b/ssh-servers/tacc_tds3.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 
 THREDDSHOST=chg-1.oden.tacc.utexas.edu # WWW hostname for emailed links
-OPENDAPHOST=tacc_tds3                  # alias in $HOME/.ssh/config
-OPENDAPPORT=":80"                      # ':80' can be an empty string, but for clarity it's here
+
+OPENDAPINDEX=catalog.html   # if set to something other than "catalog.html", DOWNLOADPREFIX is used
+                            #  by opendap_post2.sh to generate the http link address to the directory
+			    #  listing
+
+OPENDAPHOST=tacc_tds3       # alias in $HOME/.ssh/config
+OPENDAPPORT=":80"           # ':80' can be an empty string, but for clarity it's here
 OPENDAPPROTOCOL="http"
 DOWNLOADPREFIX=/asgs
 CATALOGPREFIX=/asgs

--- a/writeProperties.sh
+++ b/writeProperties.sh
@@ -94,6 +94,7 @@ writeProperties()
    echo "notification.hpc.email.notifyuser : deprecated - do not use - will be removed in the future" >> $STORMDIR_RUN_PROPERTIES
    echo "notification.opendap.email.opendapnotify : $OPENDAPNOTIFY" >> $STORMDIR_RUN_PROPERTIES
    echo "notification.email.asgsadmin : $ASGSADMIN" >> $STORMDIR_RUN_PROPERTIES
+   echo "notification.email.asgsadmin_id : $ASGSADMIN_ID" >> $STORMDIR_RUN_PROPERTIES
    echo "monitoring.logging.file.syslog : $SYSLOG" >> $STORMDIR_RUN_PROPERTIES
    # post processing
    echo "post.intendedaudience : $INTENDEDAUDIENCE" >> $STORMDIR_RUN_PROPERTIES


### PR DESCRIPTION
Issue 1124: Refining support for controlling the length and information presented in the email subjects sent via opendap_post2.sh.

Resolves #1124.
Resolves #1122.
Supercedes #1118 (PR).

Updated info at:

https://github.com/StormSurgeLive/asgs/wiki/ASGS-Operators-Guide
https://github.com/StormSurgeLive/asgs/wiki/ASGS-Cheat-Sheet
https://raw.githubusercontent.com/StormSurgeLive/asgs/561ce157c97a2b1aab08fe576a700d884892157a/ssh-servers/tacc_tds3.sh