### PR TITLE
Added a queue hint for mike III when using up to 1 full node.

### DIFF
--- a/platforms.sh
+++ b/platforms.sh
@@ -508,6 +508,15 @@ HPC_Queue_Hint()
        echo $DEFAULT_QUEUENAME
      fi
    ;;
+   "mike.hpc.lsu.edu")
+     if [[ $CPUREQUEST -eq 1 ]]; then
+       echo "single"
+     elif [[ $CPUREQUEST -le 64 ]]; then
+       echo "single"
+     else
+       echo $DEFAULT_QUEUENAME
+     fi
+   ;;
    "qbc.loni.org")
      if [[ $CPUREQUEST -eq 1 ]]; then
        echo "single"


### PR DESCRIPTION
Issue 1185: LSU HPC now requires the 'single' queue to be used when using single compute node up to the full 64 processors.

Resolves #1185.