### PR TITLE
Ensure STATEFILE file name generated from INSTANCENAME is valid

### DIFF
--- a/cloud/general/DOT-asgs-brew.sh
+++ b/cloud/general/DOT-asgs-brew.sh
@@ -314,7 +314,7 @@ _parse_config() {
     return
   fi
   # pull out var info the old fashion way...
-  export INSTANCENAME=$(egrep '^ *INSTANCENAME=' "${1}" | sed 's/^ *INSTANCENAME=//' | sed 's/ *#.*$//g')
+  export INSTANCENAME=$(egrep '^ *INSTANCENAME=' "${1}" | sed 's/^ *INSTANCENAME=//' | sed 's/ *#.*$//g' | sed -e 's/[^A-Za-z0-9._-]/_/g')
   echo "${I} config file found, instance name is '$INSTANCENAME'"
   echo
   export STATEFILE="$SCRATCH/${INSTANCENAME}.state"


### PR DESCRIPTION
Issue 1196: Added a sed command to ensure that any filename made for use as STATEFILE from INSTANCENAME will not contain invalid characters.

Resolves #1196.