### PR TITLE
Fixed a regression introduced in the stampede3 port

### DIFF
--- a/cloud/general/asgs-brew.pl
+++ b/cloud/general/asgs-brew.pl
@@ -789,9 +789,6 @@ sub get_steps {
             name        => q{Step for wgrib2},
             description => q{Downloads and builds wgrib2 on all platforms for ASGS. Note: gfortran is required, so any compiler option passed is overridden.},
             pwd         => qq{$scriptdir},
-
-            # -j > 1 breaks this makefile
-	    #command             => qq{make -j 1 NETCDFPATH=$asgs_install_path NETCDF=enable NETCDF4=enable NETCDF4_COMPRESSION=enable MACHINE_NAME=$asgs_machine_name compiler=gfortran},
 	    command             => qq{bash init-wgrib2.sh $asgs_install_path gfortran},
 	    clean               => qq{bash init-wgrib2.sh $asgs_install_path clean},
             skip_if             => sub { my ( $op, $opts_ref ) = @_; return -e qq{./bin/wgrib2}; },

--- a/cloud/general/init-wgrib2.sh
+++ b/cloud/general/init-wgrib2.sh
@@ -19,17 +19,17 @@ export CC=gcc
 export FC=gfortran
 export CXX=g++
 
-
 if [ ! -e wgrib2${VERSION}.tgz ]; then
-  #wget https://www.ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz
   wget https://asgs-static-assets.sfo2.digitaloceanspaces.com/lib/wgrib2${VERSION}.tgz
 fi
 
 rm -rf grib2
 tar zxvf wgrib2${VERSION}.tgz
 
-cd grib2
-make compiler=gfortran
+make -j 1 NETCDFPATH=$asgs_install_path NETCDF=enable NETCDF4=enable NETCDF4_COMPRESSION=enable MACHINE_NAME=$asgs_machine_name compiler=gfortran
 cp $SCRIPTDIR/grib2/wgrib2/wgrib2 $SCRIPTDIR/bin
+
+rm -rfv grib2
+rm -fv  wgrib2${VERSION}.tgz 
 
 popd

--- a/makefile
+++ b/makefile
@@ -90,6 +90,6 @@ lambertInterpRamp.x : input/lambertInterpRamp.f
 	$(FC) $(FFLAGS) $(INCLUDES) $(LIBS) -o lambertInterpRamp.x input/lambertInterpRamp.f $(LDFLAGS)
 
 wgrib2 : cleano
-	cd wgrib2
+	cd grib2
 	$(MAKE) -C grib2
 	cp grib2/wgrib2/wgrib2 ./bin


### PR DESCRIPTION
Issue 1278: The asgs-brew.pl step that was building wgrib2 was no longer calling the correct makefile. Now it is. The wrapper script added to support building the "wgrib2" step is not nearly as complex as other ones in ASGS, but this commit adds some self cleaning.

Resolves #1278.