### PR TITLE
Added quotes around exported variables in profile for Windows paths.

### DIFF
--- a/cloud/general/DOT-asgs-brew.sh
+++ b/cloud/general/DOT-asgs-brew.sh
@@ -384,7 +384,7 @@ save() {
   # includes an 'export' line for each variable asgsh cares about; this
   # is defined as part of the shell installation by asgs-brew.pl
   for e in $_ASGS_EXPORTED_VARS; do
-    echo "export ${e}='"${!e}"'"  >> "$ASGS_META_DIR/${NAME}.$$.tmp"
+    echo "export ${e}=\"${!e}\""      >> "$ASGS_META_DIR/${NAME}.$$.tmp"
   done
   mv "$ASGS_META_DIR/${NAME}.$$.tmp" "$ASGS_META_DIR/${NAME}"
 

--- a/cloud/general/asgs-brew.pl
+++ b/cloud/general/asgs-brew.pl
@@ -537,7 +537,7 @@ sub _get_env_summary {
         # filter stuff in local %ENV here that we don't want
         # dumped into the profiles
         next GETENV if grep { m/^$envar$/ } (qw/SCRIPTDIR HDF5_USE_FILE_LOCKING/);
-        $summary .= sprintf( qq{export %s=%s\n}, $envar, $ENV{$envar} // q{} );
+        $summary .= sprintf( qq{export %s="%s"\n}, $envar, $ENV{$envar} // q{} );
 
         # save to generate list of exported variables added to the locally
         # generated ./asgsh
@@ -683,7 +683,7 @@ sub get_steps {
                 PERL5LIB           => { value => qq{$scriptdir/PERL},                    how => q{append} },               # place for distributed Perl libraries
                 ADCIRC_META_DIR    => { value => qq{$asgs_home/.adcirc-meta},            how => q{replace} },              # where to track ADCIRC builds (always)
                 ASGS_META_DIR      => { value => qq{$asgs_home/profiles},                how => q{replace} },              # where to track ASGS profiles (always)
-                ASGS_BREW_FLAGS    => { value => qq{'$brewflags'},                       how => q{replace} },              # make brew flags available for later use
+                ASGS_BREW_FLAGS    => { value => qq{$brewflags},                         how => q{replace} },              # make brew flags available for later use
                 ASGS_HOME          => { value => qq{$asgs_home},                         how => q{replace} },              # used in preference of $HOME in most cases
                 ASGS_TMPDIR        => { value => qq{$asgs_tmpdir},                       how => q{replace} },              # used in preference of $TMPDIR in most cases
                 ASGS_MACHINE_NAME  => { value => qq{$asgs_machine_name},                 how => q{replace} },              # machine referred to as in platforms.sh & cmplrflags.mk

--- a/platforms/debian/init.sh
+++ b/platforms/debian/init.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # Needed for ./init-asgs.sh, bin/guess
-export WORK=${WORK:-/work}
-export SCRATCH=${SCRATCH:-/scratch}
+export WORK=${WORK:-$HOME/work}
+export SCRATCH=${SCRATCH:-$HOME/scratch}
 export DEFAULT_COMPILER=gfortran
 export HPCENV=debian.local
 export HPCENVSHORT=debian


### PR DESCRIPTION
Issue 1296: Windows paths were causing start up issues, and it was discovered that the environmental variables were not being quoted. Additionally, it was discovered and fixed that the variable, "ASGS_BREW_FLAGS", was being quoted too early in the process. This was adjusted to be treated like the others.

In addition to this, the default "$WORK" and "$SCRATCH" directories for "debian" were adjusted so that they wer under $HOME, and not a root level directory that would show unnecessary warnings for non-privileged users.

Resolves #1296.