### PR TITLE
Removed warning for older platforms in platforms.sh.

### DIFF
--- a/bin/show
+++ b/bin/show
@@ -190,8 +190,6 @@ _show() {
     platform_init)
       if [ -n "${PLATFORM_INIT}" ]; then
         echo "${I} PLATFORM_INIT is defined as '${PLATFORM_INIT}'"
-      else
-        echo "${W} PLATFORM_INIT is not defined, which may be ok; older supported platforms do not use them."
       fi
       ;;
     *) echo "'${1}' is not known to the 'show' command"

--- a/platforms.sh
+++ b/platforms.sh
@@ -325,16 +325,16 @@ env_dispatch() {
  local THIS="platforms.sh>env_dispatch()"
  scenarioMessage "$THIS: Initializing settings for ${HPCENVSHORT}."
  case $HPCENVSHORT in
-  "queenbee") consoleMessage "$I Queenbee (LONI) configuration found."
+  "queenbee") logMessage "$I Queenbee (LONI) configuration found."
           init_queenbee
           ;;
-  "supermic") consoleMessage "$I SuperMIC (LSU HPC) configuration found."
+  "supermic") logMessage "$I SuperMIC (LSU HPC) configuration found."
           init_supermic
           ;;
-  "queenbeeC") consoleMessage "$I QueenbeeC (LONI) configuration found."
+  "queenbeeC") logMessage "$I QueenbeeC (LONI) configuration found."
           init_queenbeeC
           ;;
-  "frontera") consoleMessage "$I Frontera (TACC) configuration found."
+  "frontera") logMessage "$I Frontera (TACC) configuration found."
           init_frontera
           ;;
 


### PR DESCRIPTION
Issue 1308: Removed unnecessarily scary warning. Changed a message in platforms.sh to logMessage.

Resolves #1308.

@jasonfleming - not sure about the change from scenarioMessage to logMessage, but this was getting show when ./asgsh starts. Thoughts?