### PR TITLE
Updated GNU units from 2.21 to 2.23, changed upstream fetch URL.

### DIFF
--- a/cloud/general/init-gnu-units.sh
+++ b/cloud/general/init-gnu-units.sh
@@ -19,13 +19,13 @@ if [ "$COMPILER" == "clean" ]; then
   exit
 fi
 
-UNITS_VERSION=2.21
+UNITS_VERSION=2.23
 UNITS_DIR=units-${UNITS_VERSION}
 UNITS_TGZ=${UNITS_DIR}.tar.gz
 cd $_ASGS_TMP
 
 if [ ! -e ${UNITS_TGZ} ]; then
-  wget --no-check-certificate https://ftp.gnu.org/gnu/units/${UNITS_TGZ}
+  wget --no-check-certificate https://ftpmirror.gnu.org/units/${UNITS_TGZ}
 fi
 
 rm -rf ./$UNITS_DIR 2> /dev/null


### PR DESCRIPTION
Issue 1327: The base URL for downloading this package was changed to be a mirror-selector URL, which will find the best mirror to use for downloading this tarball,

  https://ftpmirror.gnu.org/

The version of "units" was also updated from 2.21 -> 2.23.

Resolves #1327.