### PR TITLE
Fixes to support new SuperMIC including switch from PBS to SLURM

### DIFF
--- a/monitoring/captureJobID.sh
+++ b/monitoring/captureJobID.sh
@@ -47,7 +47,7 @@ case $HPCENVSHORT in
    cat jobID.tmp | awk '$1~/[0-9]+/ { print $1 }' > jobID
    rm jobID.tmp
    ;;
-"mike"|"qbd")
+"mike"|"qbd"|"supermic")
    # SLURM returns information similar to the following when a
    # job is submitted:
    # <asgsh> sbatch prep13.slurm 2>stderr >stdout
@@ -62,7 +62,7 @@ case $HPCENVSHORT in
    rm jobID.tmp
    ;;
 *)
-   # on queenbee2 and supermic at least, the jobID file contains only
+   # on queenbee2 at least, the jobID file contains only
    # the jobID, so nothing needs to be done.
    ;;
 esac

--- a/platforms.sh
+++ b/platforms.sh
@@ -76,20 +76,18 @@ init_supermic()
   local THIS="platforms.sh>env_dispatch()>init_supermic()"
   scenarioMessage "$THIS: Setting platforms-specific parameters."
   HPCENV=supermic.hpc.lsu.edu
-  QUEUESYS=PBS
+  QUEUESYS=SLURM
   PPN=20
-  QCHECKCMD=qstat
-  QSUMMARYCMD=showq
+  QCHECKCMD=sacct
   QUOTACHECKCMD=showquota
   ALLOCCHECKCMD=showquota
   QUEUENAME=workq
   SERQUEUE=single
-  SUBMITSTRING=qsub
+  SUBMITSTRING=sbatch
   QSCRIPTTEMPLATE=$SCRIPTDIR/qscript.template
   QSCRIPTGEN=qscript.pl
   OPENDAPPOST=opendap_post.sh #<~ $SCRIPTDIR/output/ assumed
-  JOBLAUNCHER='mpirun -np %totalcpu% -machinefile $PBS_NODEFILE'
-  ACCOUNT=null
+  JOBLAUNCHER='srun '
   PERL5LIB=${PERL5LIB}:${SCRIPTDIR}/PERL
   local THIS="platforms.sh>env_dispatch()>init_supermic()"
   REMOVALCMD="rmpurge"


### PR DESCRIPTION
Resolves #1334. Lots of unrelated changes on SuperMIC were also encountered, including Intel compiler upgrade from 2019 to 2021 version. Switching the queueing system on an existing HPC machine required very little change in ASGS. In any case, all Operators will have to rebuild from scratch due to the new library versions installed in the underlying OS. 

After our existing ASGS instance has successfully completed a few cycles, I will take this PR out of draft. 