### PR TITLE
Added ourPerl as "ourperl" to `fetch`, added to default PATHs

### DIFF
--- a/bin/fetch
+++ b/bin/fetch
@@ -16,7 +16,9 @@ case "${ITEM}" in
     fetch configs
     fetch cera
     fetch docs
+    fetch ourperl
     fetch storm-archive
+    # ...
     fetch adcirc-testsuite
     ;;
   asgs-mon)
@@ -24,67 +26,78 @@ case "${ITEM}" in
     pushd $SCRIPTDIR/git  > /dev/null  2>&1
     if [ -d ./asgs-mon ]; then
       echo "${W} $SCRIPTDIR/git/asgs-mon exists"
-      popd > /dev/null 2>&1 
+      popd > /dev/null 2>&1
       exit 1
     fi
     git clone git@github.com:StormSurgeLive/asgs-mon.git $SCRIPTDIR/git/asgs-mon
-    popd > /dev/null 2>&1 
+    popd > /dev/null 2>&1
     ;;
   configs)
     mkdir $SCRIPTDIR/git 2> /dev/null
     pushd $SCRIPTDIR/git  > /dev/null  2>&1
     if [ -d ./asgs-configs ]; then
       echo "${W} $SCRIPTDIR/git/asgs-configs exists"
-      popd > /dev/null 2>&1 
+      popd > /dev/null 2>&1
       exit 1
     fi
     git clone git@github.com:StormSurgeLive/asgs-configs.git $SCRIPTDIR/git/asgs-configs
-    popd > /dev/null 2>&1 
+    popd > /dev/null 2>&1
     ;;
   docs)
     mkdir $SCRIPTDIR/git 2> /dev/null
     pushd $SCRIPTDIR/git  > /dev/null  2>&1
     if [ -d ./asgs.wiki ]; then
       echo "${W} $SCRIPTDIR/git/asgs.wiki exists"
-      popd > /dev/null 2>&1 
+      popd > /dev/null 2>&1
       exit 1
     fi
     git clone git@github.com:StormSurgeLive/asgs.wiki.git $SCRIPTDIR/git/asgs.wiki
-    popd > /dev/null 2>&1 
+    popd > /dev/null 2>&1
     ;;
   cera)
     mkdir $SCRIPTDIR/git 2> /dev/null
     pushd $SCRIPTDIR/git  > /dev/null  2>&1
     if [ -d ./cera-asgs-environment ]; then
       echo "${W} $SCRIPTDIR/git/cera-asgs-environment exists"
-      popd > /dev/null 2>&1 
+      popd > /dev/null 2>&1
       exit 1
     fi
     git clone git@github.com:CERA-GROUP/cera-asgs-environment.git $SCRIPTDIR/git/cera-asgs-environment
 
-    popd > /dev/null 2>&1 
+    popd > /dev/null 2>&1
+    ;;
+  ourperl)
+    mkdir $SCRIPTDIR/git 2> /dev/null
+    pushd $SCRIPTDIR/git  > /dev/null  2>&1
+    if [ -d ./ourPerl ]; then
+      echo "${W} $SCRIPTDIR/git/asgs.wiki exists"
+      popd > /dev/null 2>&1
+      exit 1
+    fi
+    git clone git@github.com:StormSurgeLive/ourPerl.git $SCRIPTDIR/git/ourPerl
+    popd > /dev/null 2>&1
     ;;
   storm-archive)
     mkdir $SCRIPTDIR/git 2> /dev/null
     pushd $SCRIPTDIR/git  > /dev/null  2>&1
     if [ -d ./storm-archive ]; then
       echo "${W} $SCRIPTDIR/git/storm-archive exists"
-      popd > /dev/null 2>&1 
+      popd > /dev/null 2>&1
       exit 1
     fi
     git clone git@github.com:StormSurgeLive/storm-archive.git $SCRIPTDIR/git/storm-archive
-    popd > /dev/null 2>&1 
+    popd > /dev/null 2>&1
     ;;
   adcirc-testsuite)
     mkdir $SCRIPTDIR/git 2> /dev/null
     pushd $SCRIPTDIR/git  > /dev/null  2>&1
     if [ -d ./adcirc-testsuite ]; then
       echo "${W} $SCRIPTDIR/git/adcirc-testsuite exists"
-      popd > /dev/null 2>&1 
+      popd > /dev/null 2>&1
       exit 1
     fi
     git clone git@github.com:adcirc/adcirc-testsuite.git $SCRIPTDIR/git/adcirc-testsuite
-    popd > /dev/null 2>&1 
+    popd > /dev/null 2>&1
     ;;
   *)
     cat << EOF
@@ -104,7 +117,7 @@ case "${ITEM}" in
  Example, checkout ASGS configs into, "$SCRIPTDIR/git/asgs-configs":
 
  asgs> fetch configs
- 
+
 Note: Create a GH issue if there is something missing here that
 you think should be added.
 EOF

--- a/bin/fetch
+++ b/bin/fetch
@@ -70,7 +70,7 @@ case "${ITEM}" in
     mkdir $SCRIPTDIR/git 2> /dev/null
     pushd $SCRIPTDIR/git  > /dev/null  2>&1
     if [ -d ./ourPerl ]; then
-      echo "${W} $SCRIPTDIR/git/asgs.wiki exists"
+      echo "${W} $SCRIPTDIR/git/ourPerl exists"
       popd > /dev/null 2>&1
       exit 1
     fi
@@ -105,12 +105,13 @@ case "${ITEM}" in
 '$ITEM' not supported via ASGS' "fetch" command
 
  Supported:
-  * adcirc-testsuite - git clones ADCIRC's test-suite        (public)
-  * asgs-mon         - git clones ASGS' monitor              (public)
-  * cera             - git clones CERA local-asgs-assets     (private)
-  * configs          - git clones ASGS asgs-config           (public)
-  * docs             - git clones ASGS asgs.wiki             (public)
-  * storm-archive    - git clones ASGS storm-archive         (public)
+  * adcirc-testsuite - git clones ADCIRC's test-suite         (public)
+  * asgs-mon         - git clones ASGS' monitor               (public)
+  * cera             - git clones CERA local-asgs-assets      (private)
+  * configs          - git clones ASGS asgs-config            (public)
+  * docs             - git clones ASGS asgs.wiki              (public)
+  * ourperl          - git clones ASGS fork of Nate's ourPerl (public)
+  * storm-archive    - git clones ASGS storm-archive          (public)
   --                 ---
   * all              - attempts all of the above
 

--- a/cloud/general/asgs-brew.pl
+++ b/cloud/general/asgs-brew.pl
@@ -660,6 +660,18 @@ sub get_steps {
             util/input/nodalattr
             util/output
             util/troubleshooting
+            git/asgs-mon/bin/
+            git/ourPerl/KML
+            git/ourPerl/StwaveUtils
+            git/ourPerl/Date
+            git/ourPerl/Mapping
+            git/ourPerl/Geometry
+            git/ourPerl/Lidar
+            git/ourPerl/DataGetters
+            git/ourPerl/Overtopping
+            git/ourPerl/XtremeValStats
+            git/ourPerl/SwanUtils
+            git/ourPerl/AdcircUtils
             ]
         ) {
             push @all_paths, sprintf( "%s/%s", $scriptdir, $dir );
@@ -694,23 +706,23 @@ sub get_steps {
                 PATH               => { value => $_get_all_paths->(), how => q{prepend} },                                 # prefer ASGS binaries and tools; full list managed above
                 WORK               => { value => $ENV{WORK}    // $asgs_home // q{}, how => q{replace} },                  # standardize across all platforms
                 SCRATCH            => { value => $ENV{SCRATCH} // $ENV{WORK} // $asgs_home // q{}, how => q{replace} },    # standardize across all platforms
-                LIBRARY_PATH       => { value => qq{$asgs_install_path/lib},             how => q{prepend} },              # for use by linkers
-                LD_LIBRARY_PATH    => { value => qq{$asgs_install_path/lib},             how => q{prepend} },              # for use by linkers
-                LD_RUN_PATH        => { value => qq{$asgs_install_path/lib},             how => q{prepend} },              # for use by binaries
-                LD_INCLUDE_PATH    => { value => qq{$asgs_install_path/include},         how => q{prepend} },              # for use by compilers
-                SCRIPTDIR          => { value => qq{$scriptdir},                         how => q{replace} },              # base ASGS dir, used by asgs_main.sh
-                PERL5LIB           => { value => qq{$scriptdir/PERL},                    how => q{append} },               # place for distributed Perl libraries
-                ADCIRC_META_DIR    => { value => qq{$asgs_home/.adcirc-meta},            how => q{replace} },              # where to track ADCIRC builds (always)
-                ASGS_META_DIR      => { value => qq{$asgs_home/profiles},                how => q{replace} },              # where to track ASGS profiles (always)
-                ASGS_BREW_FLAGS    => { value => qq{$brewflags},                         how => q{replace} },              # make brew flags available for later use
-                ASGS_HOME          => { value => qq{$asgs_home},                         how => q{replace} },              # used in preference of $HOME in most cases
-                ASGS_TMPDIR        => { value => qq{$asgs_tmpdir},                       how => q{replace} },              # used in preference of $TMPDIR in most cases
-                ASGS_MACHINE_NAME  => { value => qq{$asgs_machine_name},                 how => q{replace} },              # machine referred to as in platforms.sh & cmplrflags.mk
-                ASGS_COMPILER      => { value => qq{$asgs_compiler},                     how => q{replace} },              # compiler family designated during asgs-brew.pl build
-                ASGS_INSTALL_PATH  => { value => qq{$asgs_install_path},                 how => q{replace} },              # where asgs-brew.pl installs supporting bins & libs
-                ASGS_MAKEJOBS      => { value => qq{$makejobs},                          how => q{replace} },              # passed to make commands where Makefile supports
-                ASGS_MESH_DEFAULTS => { value => qq{$scriptdir/config/mesh_defaults.sh}, how => q{replace} },              # list of supported meshes
-                ASGS_PLATFORMS     => { value => qq{$scriptdir/platforms.sh},            how => q{replace} },              # list of supported platforms
+                LIBRARY_PATH       => { value => qq{$asgs_install_path/lib},                 how => q{prepend} },          # for use by linkers
+                LD_LIBRARY_PATH    => { value => qq{$asgs_install_path/lib},                 how => q{prepend} },          # for use by linkers
+                LD_RUN_PATH        => { value => qq{$asgs_install_path/lib},                 how => q{prepend} },          # for use by binaries
+                LD_INCLUDE_PATH    => { value => qq{$asgs_install_path/include},             how => q{prepend} },          # for use by compilers
+                SCRIPTDIR          => { value => qq{$scriptdir},                             how => q{replace} },          # base ASGS dir, used by asgs_main.sh
+                PERL5LIB           => { value => qq{$scriptdir/PERL:$scriptdir/git/ourPerl}, how => q{append}  },          # place for distributed Perl libraries
+                ADCIRC_META_DIR    => { value => qq{$asgs_home/.adcirc-meta},                how => q{replace} },          # where to track ADCIRC builds (always)
+                ASGS_META_DIR      => { value => qq{$asgs_home/profiles},                    how => q{replace} },          # where to track ASGS profiles (always)
+                ASGS_BREW_FLAGS    => { value => qq{$brewflags},                             how => q{replace} },          # make brew flags available for later use
+                ASGS_HOME          => { value => qq{$asgs_home},                             how => q{replace} },          # used in preference of $HOME in most cases
+                ASGS_TMPDIR        => { value => qq{$asgs_tmpdir},                           how => q{replace} },          # used in preference of $TMPDIR in most cases
+                ASGS_MACHINE_NAME  => { value => qq{$asgs_machine_name},                     how => q{replace} },          # machine referred to as in platforms.sh & cmplrflags.mk
+                ASGS_COMPILER      => { value => qq{$asgs_compiler},                         how => q{replace} },          # compiler family designated during asgs-brew.pl build
+                ASGS_INSTALL_PATH  => { value => qq{$asgs_install_path},                     how => q{replace} },          # where asgs-brew.pl installs supporting bins & libs
+                ASGS_MAKEJOBS      => { value => qq{$makejobs},                              how => q{replace} },          # passed to make commands where Makefile supports
+                ASGS_MESH_DEFAULTS => { value => qq{$scriptdir/config/mesh_defaults.sh},     how => q{replace} },          # list of supported meshes
+                ASGS_PLATFORMS     => { value => qq{$scriptdir/platforms.sh},                how => q{replace} },          # list of supported platforms
             },
         },
         {


### PR DESCRIPTION
Issue 1364: Added our fork of Nate's Perl repo to the `fetch` command, use `fetch ourperl`. Updated default PATHs in asgs-brew to include the directories in git/ourPerl and git/asgs-mon; it should be okay that they are fixed like that, it's how all the others were added.

Resolves #1364.