### PR TITLE
Replaced Net::FTP with HTTP::Tiny based "ls".

### DIFF
--- a/bin/get_gfs_status.pl
+++ b/bin/get_gfs_status.pl
@@ -34,7 +34,6 @@ use Getopt::Long;
 use JSON::PP;
 use Cwd;
 use ASGSUtil;
-use Util::H2O::More qw/ddd/;
 #
 my $startcycle = "null";  # optional arg that indicates start of range of interest
 my $backsite = "null";    # ncep ftp site for gfs data


### PR DESCRIPTION
Issue 1373: This change uses HTTP over FTP for getting lists of files and directories, something needed on TACC's Lonestar6 for some reason.

Resolves #1373.