### PR TITLE
Made some operator UX improvements, around configs and asgs-mon.

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+if [ -z "$_ASGSH_PID" ]; then
+  echo "This script is meant to run inside of the ASGS Shell Environment, asgsh."
+  exit 1;
+fi
+
+# this is just a starter, the above stuff might go into a shell "library" at some
+# point
+
+# 'build' is basically ASGS Shell Environment's "package manager"
+# these are the "optional" installs - from individual utilities
+# to "bundles" (e.g., a set of related, but optional Perl modules)
+build() {
+  TO_BUILD=${1}
+  BUILD_OPTS=${2}
+  case "${TO_BUILD}" in
+    adcirc)
+      init-adcirc.sh ${BUILD_OPTS}
+      ;;
+    jq)
+      init-jq.sh ${ASGS_INSTALL_PATH} ${BUILD_OPTS}
+      ;;
+    pdl)
+      init-perl-data-language.sh ${ASGS_INSTALL_PATH} ${BUILD_OPTS}
+      ;;
+    perl-dev)
+      init-perldev-env.sh ${ASGS_INSTALL_PATH} ${BUILD_OPTS}
+      ;;
+    replaycli)
+      init-replaycli.sh ${ASGS_INSTALL_PATH} ${BUILD_OPTS}
+      ;;
+    *)
+      echo 'Supported "build" options:'
+      echo '  adcirc    - ADCIRC build wizard supporting different versions and patchsets'
+      echo '  jq        - "a lightweight and flexible command-line JSON processor"'
+      echo '  pdl       - installs the latest version of the Perl Data Language (PDL)'
+      echo '  perl-dev  - installs tools useful for Perl development (e.g., Dist::Zilla)'
+      echo '  replaycli - a client for StormReplay.com, an ASGS related service'
+      ;;
+  esac
+}
+
+build $@

--- a/bin/fetch
+++ b/bin/fetch
@@ -22,12 +22,14 @@ case "${ITEM}" in
     fetch adcirc-testsuite
     ;;
   asgs-mon)
+    build jq                 # helps parse JSON 
     mkdir $SCRIPTDIR/git 2> /dev/null
     pushd $SCRIPTDIR/git  > /dev/null  2>&1
     if [ -d ./asgs-mon ]; then
-      echo "${W} $SCRIPTDIR/git/asgs-mon exists"
-      popd > /dev/null 2>&1
-      exit 1
+      cd ./asgs-mon  > /dev/null  2>&1
+      git pull origin master
+      popd > /dev/null 2>&1 
+      exit
     fi
     git clone git@github.com:StormSurgeLive/asgs-mon.git $SCRIPTDIR/git/asgs-mon
     popd > /dev/null 2>&1
@@ -36,9 +38,10 @@ case "${ITEM}" in
     mkdir $SCRIPTDIR/git 2> /dev/null
     pushd $SCRIPTDIR/git  > /dev/null  2>&1
     if [ -d ./asgs-configs ]; then
-      echo "${W} $SCRIPTDIR/git/asgs-configs exists"
-      popd > /dev/null 2>&1
-      exit 1
+      cd ./asgs-configs  > /dev/null  2>&1
+      git pull origin master
+      popd > /dev/null 2>&1 
+      exit
     fi
     git clone git@github.com:StormSurgeLive/asgs-configs.git $SCRIPTDIR/git/asgs-configs
     popd > /dev/null 2>&1
@@ -47,9 +50,10 @@ case "${ITEM}" in
     mkdir $SCRIPTDIR/git 2> /dev/null
     pushd $SCRIPTDIR/git  > /dev/null  2>&1
     if [ -d ./asgs.wiki ]; then
-      echo "${W} $SCRIPTDIR/git/asgs.wiki exists"
-      popd > /dev/null 2>&1
-      exit 1
+      cd ./asgs.wiki  > /dev/null  2>&1
+      git pull origin master
+      popd > /dev/null 2>&1 
+      exit
     fi
     git clone git@github.com:StormSurgeLive/asgs.wiki.git $SCRIPTDIR/git/asgs.wiki
     popd > /dev/null 2>&1
@@ -58,9 +62,10 @@ case "${ITEM}" in
     mkdir $SCRIPTDIR/git 2> /dev/null
     pushd $SCRIPTDIR/git  > /dev/null  2>&1
     if [ -d ./cera-asgs-environment ]; then
-      echo "${W} $SCRIPTDIR/git/cera-asgs-environment exists"
-      popd > /dev/null 2>&1
-      exit 1
+      cd ./cera-asgs-environment  > /dev/null  2>&1
+      git pull origin master
+      popd > /dev/null 2>&1 
+      exit
     fi
     git clone git@github.com:CERA-GROUP/cera-asgs-environment.git $SCRIPTDIR/git/cera-asgs-environment
 
@@ -70,9 +75,10 @@ case "${ITEM}" in
     mkdir $SCRIPTDIR/git 2> /dev/null
     pushd $SCRIPTDIR/git  > /dev/null  2>&1
     if [ -d ./ourPerl ]; then
-      echo "${W} $SCRIPTDIR/git/ourPerl exists"
-      popd > /dev/null 2>&1
-      exit 1
+      cd ./ourPerl  > /dev/null  2>&1
+      git pull origin master
+      popd > /dev/null 2>&1 
+      exit
     fi
     git clone git@github.com:StormSurgeLive/ourPerl.git $SCRIPTDIR/git/ourPerl
     popd > /dev/null 2>&1
@@ -81,9 +87,10 @@ case "${ITEM}" in
     mkdir $SCRIPTDIR/git 2> /dev/null
     pushd $SCRIPTDIR/git  > /dev/null  2>&1
     if [ -d ./storm-archive ]; then
-      echo "${W} $SCRIPTDIR/git/storm-archive exists"
-      popd > /dev/null 2>&1
-      exit 1
+      cd ./storm-archive  > /dev/null  2>&1
+      git pull origin master
+      popd > /dev/null 2>&1 
+      exit
     fi
     git clone git@github.com:StormSurgeLive/storm-archive.git $SCRIPTDIR/git/storm-archive
     popd > /dev/null 2>&1
@@ -92,9 +99,10 @@ case "${ITEM}" in
     mkdir $SCRIPTDIR/git 2> /dev/null
     pushd $SCRIPTDIR/git  > /dev/null  2>&1
     if [ -d ./adcirc-testsuite ]; then
-      echo "${W} $SCRIPTDIR/git/adcirc-testsuite exists"
-      popd > /dev/null 2>&1
-      exit 1
+      cd ./adcirc-testsuite  > /dev/null  2>&1
+      git pull origin master
+      popd > /dev/null 2>&1 
+      exit
     fi
     git clone git@github.com:adcirc/adcirc-testsuite.git $SCRIPTDIR/git/adcirc-testsuite
     popd > /dev/null 2>&1
@@ -103,6 +111,8 @@ case "${ITEM}" in
     cat << EOF
 
 '$ITEM' not supported via ASGS' "fetch" command
+
+Rerunning the command will update the repo if possible.
 
  Supported:
   * adcirc-testsuite - git clones ADCIRC's test-suite         (public)

--- a/cloud/general/DOT-asgs-brew.sh
+++ b/cloud/general/DOT-asgs-brew.sh
@@ -140,6 +140,14 @@ goto() {
       echo "ADCIRCDIR not yet defined"
     fi
     ;;
+  configdir)
+    if [ -n "$ASGS_CONFIG" ]; then
+       cd $(dirname "$ASGS_CONFIG")
+      _pwd
+    else
+      echo "ASGS_CONFIG not yet defined"
+    fi
+    ;;
   installdir)
     if [ -e "$ASGS_INSTALL_PATH" ]; then
       cd $ASGS_INSTALL_PATH
@@ -189,7 +197,12 @@ goto() {
     fi
     ;;
   *)
-    echo 'Only "adcircdir", "rundir", "scratchdir", "scriptdir", and "workdir" are supported at this time.'
+    if [ -d "${1}" ]; then
+      cd "${1}"
+      _pwd
+    else
+      echo 'Only "adcircdir", "configdir", "rundir", "scratchdir", "scriptdir", and "workdir" are supported at this time.'
+    fi
     ;;
   esac
 }
@@ -1142,39 +1155,6 @@ fi
 # initialization, do after bash functions have been loaded
 source $SCRIPTDIR/etc/PS1.sh
 
-# 'build' is basically ASGS Shell Environment's "package manager"
-# these are the "optional" installs - from individual utilities
-# to "bundles" (e.g., a set of related, but optional Perl modules)
-build() {
-  TO_BUILD=${1}
-  BUILD_OPTS=${2}
-  case "${TO_BUILD}" in
-    adcirc)
-      init-adcirc.sh ${BUILD_OPTS}
-      ;;
-    jq)
-      init-jq.sh ${ASGS_INSTALL_PATH} ${BUILD_OPTS}
-      ;;
-    pdl)
-      init-perl-data-language.sh ${ASGS_INSTALL_PATH} ${BUILD_OPTS}
-      ;;
-    perl-dev)
-      init-perldev-env.sh ${ASGS_INSTALL_PATH} ${BUILD_OPTS}
-      ;;
-    replaycli)
-      init-replaycli.sh ${ASGS_INSTALL_PATH} ${BUILD_OPTS}
-      ;;
-    *)
-      echo 'Supported "build" options:'
-      echo '  adcirc    - ADCIRC build wizard supporting different versions and patchsets'
-      echo '  jq        - "a lightweight and flexible command-line JSON processor"'
-      echo '  pdl       - installs the latest version of the Perl Data Language (PDL)'
-      echo '  perl-dev  - installs tools useful for Perl development (e.g., Dist::Zilla)'
-      echo '  replaycli - a client for StormReplay.com, an ASGS related service'
-      ;;
-  esac
-}
-
 # deprecation (may change *again* if we create a general install manager
 initadcirc(){
   echo "(deprecation notice): 'initadcirc' should now be called as, 'build adcirc'."
@@ -1215,6 +1195,7 @@ alias ll='ls -l --color=auto'
 alias ls='ls --color=auto'
 
 # handy aliases for the impatient
+alias ap="alias -p"
 alias a="list adcirc"
 alias c="edit config"
 alias ds="delete statefile"
@@ -1233,6 +1214,15 @@ alias ve="verify email"
 alias vp="verify perl"
 alias vr="verify regressions"
 alias vs="verify ssh_config"
+
+# aliases for common git repos used during operations 
+alias aconfigs="goto $SCRIPTDIR/git/asgs-configs/$(date +%Y)"              # cd in this year's directory in git/asgs-configs
+alias amond="goto $SCRIPTDIR/git/asgs-mon"                                 # cd into asgs-mon's directory
+alias amonv="$SCRIPTDIR/git/asgs-mon/bin/asgs-mon -v"                      # run 'asgs-mon -v'
+alias cera="goto $SCRIPTDIR/git/cera-asgs-environment"                     # cd into cera-asgs-environment's directory
+alias cerad="goto $SCRIPTDIR/git/cera-asgs-environment/asgs-configs-daily" # cd into cera-asgs-environment's daily configs directory
+alias docsd="goto $SCRIPTDIR/git/asgs.wiki"                                # cd into asgs.wiki's directory
+alias gc="goto configdir"                                                  # cd to the directory containing ASGS_CONFIG if set
 
 if [ -n "$_asgsh_splash" ]; then
 # show important directories

--- a/cloud/general/init-jq.sh
+++ b/cloud/general/init-jq.sh
@@ -18,10 +18,12 @@ if [[ "$COMPILER" == "clean" || "$COMPILER" == "rebuild" ]]; then
   rm -vf ./lib/libjq.so
   rm -vf ./bin/jq
   rm -vf ./include/jq.h
+  rm -vrf ./share/doc/jq
+  rm -vf ./lib/pkgconfig/libjq.pc
   popd $OPT > /dev/null 2>&1
   echo cleaning jq build scripts and downloads
   cd $_ASGS_TMP
-  rm -rfv ${JQ_DIR}* > /dev/null 2>&1
+  rm -vrf ${JQ_DIR}* > /dev/null 2>&1
 
   # stop here if 'clean', proceed if 'rebuild'
   if [ "$COMPILER" == "clean" ]; then
@@ -34,7 +36,7 @@ if [ -x ${OPT}/bin/jq ]; then
   exit
 fi
 
-JQ_VERSION=1.6
+JQ_VERSION=1.7.1
 JQ_DIR=jq-${JQ_VERSION}
 JQ_TGZ=${JQ_DIR}.tar.gz
 cd $_ASGS_TMP


### PR DESCRIPTION
Issue 1379:
Issue 1380:

* update 'jq' from 1.6 -> 1.7.1
* moved 'build' to bin/build
* created bin/push to more easily push changes to some bin/fetch'd repos
  - `git/asgs-mon` (`fetch asgs-mon` also installs `jq` via `bin/build`)
  - `git/asgs-configs`
  - `git/docs`
* added the following aliases and short cuts for jumping in and out of config dirs
  - `aconfigs` # cd in this year's directory in git/asgs-configs
  - `amond`    # cd into asgs-mon's directory
  - `amonv`    # run 'asgs-mon -v'
  - `cera`     # cd into cera-asgs-environment's directory
  - `cerad`    # cd into cera-asgs-environment's daily configs directory
  - `docsd`    # cd into asgs.wiki's directory
  - `gc`       # cd to the directory containing ASGS_CONFIG if set
