### PR TITLE
Removed trailing '/' in asgs-mon's PATH entry in asgs-brew

### DIFF
--- a/cloud/general/DOT-asgs-brew.sh
+++ b/cloud/general/DOT-asgs-brew.sh
@@ -1218,7 +1218,7 @@ alias vs="verify ssh_config"
 # aliases for common git repos used during operations 
 alias aconfigs="goto $SCRIPTDIR/git/asgs-configs/$(date +%Y)"              # cd in this year's directory in git/asgs-configs
 alias amond="goto $SCRIPTDIR/git/asgs-mon"                                 # cd into asgs-mon's directory
-alias amonv="$SCRIPTDIR/git/asgs-mon/bin/asgs-mon -v"                      # run 'asgs-mon -v'
+alias amonv="asgs-mon -v"                                                  # run 'asgs-mon -v' (it's in PATH)
 alias cera="goto $SCRIPTDIR/git/cera-asgs-environment"                     # cd into cera-asgs-environment's directory
 alias cerad="goto $SCRIPTDIR/git/cera-asgs-environment/asgs-configs-daily" # cd into cera-asgs-environment's daily configs directory
 alias docsd="goto $SCRIPTDIR/git/asgs.wiki"                                # cd into asgs.wiki's directory

--- a/cloud/general/asgs-brew.pl
+++ b/cloud/general/asgs-brew.pl
@@ -660,7 +660,7 @@ sub get_steps {
             util/input/nodalattr
             util/output
             util/troubleshooting
-            git/asgs-mon/bin/
+            git/asgs-mon/bin
             git/ourPerl/KML
             git/ourPerl/StwaveUtils
             git/ourPerl/Date


### PR DESCRIPTION
Issue 1379: minor thing I noticed when doing, `which asgs-mon`; adjusted "asmv" alias to use fact asgs-mon is in PATH now.

Related to #1379