### PR TITLE
Updating ADCIRC for building on QBC after their upgrade to Redhat8.

### DIFF
--- a/patches/ADCIRC/v53release/01-cmplrflags-mk.patch
+++ b/patches/ADCIRC/v53release/01-cmplrflags-mk.patch
@@ -1,5 +1,5 @@
 diff --git a/work/cmplrflags.mk b/work/cmplrflags.mk
-index 2c0eb06..55b19d1 100644
+index 2c0eb06..5a3a820 100644
 --- a/work/cmplrflags.mk
 +++ b/work/cmplrflags.mk
 @@ -89,13 +89,10 @@ ifeq ($(compiler),gnu)
@@ -113,7 +113,7 @@ index 2c0eb06..55b19d1 100644
    CFLAGS        := $(INCDIRS) -O2 -xSSE4.2 -m64 -mcmodel=medium -DLINUX
    FLIBS         :=
    ifeq ($(DEBUG),full)
-@@ -248,45 +247,124 @@ ifeq ($(compiler),intel)
+@@ -248,45 +247,125 @@ ifeq ($(compiler),intel)
       FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -DNETCDF_TRACE -DFULL_STACK -DFLUSH_MESSAGES
    endif
    #
@@ -171,6 +171,7 @@ index 2c0eb06..55b19d1 100644
 -     CFLAGS  := $(INCDIRS) -O3 -DLINUX -xAVX
 +  endif
 +  ifeq ($(MACHINENAME),queenbeeC)
++     PFC     :=  mpiifort
 +     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xCORE-AVX512
 +     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX512
 +     FLIBS   := $(INCDIRS) -xCORE-AVX512
@@ -263,7 +264,7 @@ index 2c0eb06..55b19d1 100644
    endif
    #
    #@jasonfleming Added to fix bus error on hatteras@renci
-@@ -302,67 +380,66 @@ ifeq ($(compiler),intel)
+@@ -302,67 +381,66 @@ ifeq ($(compiler),intel)
       DPRE          := $(DPRE) -DADCSWAN
    endif
    IMODS         :=  -I
@@ -358,7 +359,7 @@ index 2c0eb06..55b19d1 100644
       ifeq ($(MACHINENAME),killdevil)
          HDF5HOME       :=/nas02/apps/hdf5-1.8.5/lib
          NETCDFHOME     :=/nas02/apps/netcdf-4.1.1
-@@ -384,7 +461,7 @@ ifeq ($(compiler),intel-ND)
+@@ -384,7 +462,7 @@ ifeq ($(compiler),intel-ND)
    PPFC            :=  ifort
    FC            :=  ifort
    PFC           :=  mpif90
@@ -367,7 +368,7 @@ index 2c0eb06..55b19d1 100644
    ifeq ($(DEBUG),full)
       FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -debug -check all -i-dynamic -FI -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
    endif
-@@ -399,15 +476,15 @@ ifeq ($(compiler),intel-ND)
+@@ -399,15 +477,15 @@ ifeq ($(compiler),intel-ND)
    IMODS         :=  -I
    CC            := icc
    CCBE          := $(CC)
@@ -386,7 +387,7 @@ index 2c0eb06..55b19d1 100644
    CLIBS         :=
    MSGLIBS       :=
    $(warning (INFO) Corresponding machine found in cmplrflags.mk.)
-@@ -428,7 +505,7 @@ ifeq ($(compiler),intel-sgi)
+@@ -428,7 +506,7 @@ ifeq ($(compiler),intel-sgi)
    PFC           :=  mpif90
    CC            :=  icc -O2 -no-ipo
    CCBE          :=  icc -O2 -no-ipo
@@ -395,7 +396,7 @@ index 2c0eb06..55b19d1 100644
  #  FFLAGS1      :=  $(INCDIRS) -Mextend -g -O0 -traceback
    FFLAGS2       :=  $(FFLAGS1)
    FFLAGS3       :=  $(FFLAGS1) -assume buffered_stdout
-@@ -504,7 +581,7 @@ ifeq ($(compiler),cray_xt4)
+@@ -504,7 +582,7 @@ ifeq ($(compiler),cray_xt4)
    PFC	        :=  ftn
    CC		:=  pgcc
    CCBE		:=  cc
@@ -404,7 +405,7 @@ index 2c0eb06..55b19d1 100644
    ifeq ($(DEBUG),full)
       FFLAGS1	:=  $(INCDIRS) -Mextend -g -O0 -traceback -Mbounds -Mchkfpstk -Mchkptr -Mchkstk -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK
    endif
-@@ -584,7 +661,7 @@ ifeq ($(compiler),xtintel)
+@@ -584,7 +662,7 @@ ifeq ($(compiler),xtintel)
    PFC           :=  ftn
    CC            :=  cc -O2 -no-ipo
    CCBE          :=  cc -O2 -no-ipo
@@ -413,7 +414,7 @@ index 2c0eb06..55b19d1 100644
  #  FFLAGS1      :=  $(INCDIRS) -Mextend -g -O0 -traceback
    FFLAGS2       :=  $(FFLAGS1)
    FFLAGS3       :=  $(FFLAGS1) -assume buffered_stdout
-@@ -716,8 +793,8 @@ ifeq ($(compiler),diamond)
+@@ -716,8 +794,8 @@ ifeq ($(compiler),diamond)
    PPFC          :=  ifort
    FC            :=  ifort
    PFC           :=  ifort
@@ -424,7 +425,7 @@ index 2c0eb06..55b19d1 100644
    ifeq ($(DEBUG),full)
       FFLAGS1	:=  $(INCDIRS) -g -O0 -debug -fpe0 -132 -traceback -check all -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK
    endif
-@@ -732,8 +809,8 @@ ifeq ($(compiler),diamond)
+@@ -732,8 +810,8 @@ ifeq ($(compiler),diamond)
    IMODS         :=  -I
    CC            := icc
    CCBE          := $(CC)
@@ -435,7 +436,7 @@ index 2c0eb06..55b19d1 100644
    ifeq ($(DEBUG),full)
       CFLAGS        := $(INCDIRS) -g -O0
    endif
-@@ -784,7 +861,7 @@ ifeq ($(compiler),garnet)
+@@ -784,7 +862,7 @@ ifeq ($(compiler),garnet)
       CFLAGS	:=  $(INCDIRS) -DLINUX -g -O0
    endif
    IMODS		:=  -module
@@ -444,7 +445,7 @@ index 2c0eb06..55b19d1 100644
  # jgf20110728: on Garnet, NETCDFHOME=/opt/cray/netcdf/4.1.1.0/netcdf-pgi
  # jgf20110815: on Garnet, HDF5HOME=/opt/cray/hdf5/default/hdf5-pgi
  # jgf20130815: on Garnet, load module cray-netcdf, with the path to the
-@@ -809,7 +886,7 @@ ifeq ($(compiler),kraken)
+@@ -809,7 +887,7 @@ ifeq ($(compiler),kraken)
    PPFC          :=  ftn
    FC            :=  ftn
    PFC           :=  ftn
@@ -453,7 +454,7 @@ index 2c0eb06..55b19d1 100644
    FFLAGS2       :=  $(FFLAGS1)
    FFLAGS3       :=  $(FFLAGS1)
    DA            :=  -DREAL8 -DLINUX -DCSCA -DPOWELL
-@@ -845,7 +922,7 @@ ifeq ($(compiler),circleci)
+@@ -845,7 +923,7 @@ ifeq ($(compiler),circleci)
    IMODS 	:=  -I
    CC		:= gcc
    CCBE		:= $(CC)
@@ -462,7 +463,7 @@ index 2c0eb06..55b19d1 100644
    CLIBS	:=
    LIBS		:=
    MSGLIBS	:=
-@@ -859,8 +936,7 @@ ifeq ($(compiler),circleci)
+@@ -859,8 +937,7 @@ ifeq ($(compiler),circleci)
       MULTIPLE := TRUE
    endif
  endif
@@ -472,7 +473,7 @@ index 2c0eb06..55b19d1 100644
  #$(MACHINE)
  ########################################################################
  # Compiler flags for Linux operating system on 32bit x86 CPU
-@@ -950,7 +1026,7 @@ ifeq ($(compiler),gnu)
+@@ -950,7 +1027,7 @@ ifeq ($(compiler),gnu)
       FFLAGS1	:=  $(INCDIRS) -g -O0 -ffixed-line-length-132 -ftrace=full -fbounds-check -DNETCDF_TRACE -DFLUSH_MESSAGES -DFULL_STACK
    endif
    ifeq ($(DEBUG),valgrind)
@@ -481,7 +482,7 @@ index 2c0eb06..55b19d1 100644
    endif
    ifeq ($(SWAN),enable)
       FFLAGS1    :=  $(FFLAGS1) -freal-loops
-@@ -988,69 +1064,6 @@ ifeq ($(compiler),gnu)
+@@ -988,69 +1065,6 @@ ifeq ($(compiler),gnu)
    endif
  endif
  #
@@ -551,7 +552,7 @@ index 2c0eb06..55b19d1 100644
  endif
  
  ########################################################################
-@@ -1095,7 +1108,7 @@ ifeq ($(arch),altix)
+@@ -1095,7 +1109,7 @@ ifeq ($(arch),altix)
    PPFC            := ifort
    FC              := ifort
    PFC             := ifort
@@ -560,7 +561,7 @@ index 2c0eb06..55b19d1 100644
    FFLAGS2	  := $(FFLAGS1)
    FFLAGS3	  := $(FFLAGS1)
    DA	          :=  -DREAL8 -DCSCA
-@@ -1168,7 +1181,7 @@ ifeq ($(IBM),p5)
+@@ -1168,7 +1182,7 @@ ifeq ($(IBM),p5)
    FFLAGS0       := $(INCDIRS) -w -qfixed=132 -qarch=auto -qcache=auto
    FFLAGS1       := $(FFLAGS0) -O2
    FFLAGS2       := $(FFLAGS0) -qhot -qstrict
@@ -569,7 +570,7 @@ index 2c0eb06..55b19d1 100644
    DA            := -WF,"-DREAL8,-DIBM,-DCSCA"
    DP            := -tF -WF,"-DREAL8,-DIBM,-DCSCA,-DCMPI"
    DPRE          := -tF -WF,"-DREAL8,-DIBM"
-@@ -1488,9 +1501,9 @@ ifneq (,$(findstring powerpc-darwin,$(MACHINE)-$(OS)))
+@@ -1488,9 +1502,9 @@ ifneq (,$(findstring powerpc-darwin,$(MACHINE)-$(OS)))
    PPFC	        := f90
    FC	        := f90
    PFC	        := mpif77
@@ -582,7 +583,7 @@ index 2c0eb06..55b19d1 100644
    DA  	   	:=  -DREAL8 -DCSCA -DLINUX
    DP  	   	:=  -DREAL8 -DCSCA -DCMPI -DLINUX
    DPRE	   	:=  -DREAL8 -DLINUX
-@@ -1518,17 +1531,17 @@ ifneq (,$(findstring i386-darwin,$(MACHINE)-$(OS)))
+@@ -1518,17 +1532,17 @@ ifneq (,$(findstring i386-darwin,$(MACHINE)-$(OS)))
    PPFC	        := ifort
    FC	        := ifort
    PFC	        := mpif77

--- a/patches/ADCIRC/v55.01-5bc04d6/01-cmplrflags-mk.patch
+++ b/patches/ADCIRC/v55.01-5bc04d6/01-cmplrflags-mk.patch
@@ -1,5 +1,5 @@
 diff --git a/work/cmplrflags.mk b/work/cmplrflags.mk
-index 50d4603..a38a1ba 100644
+index 50d4603..c3d4a2b 100644
 --- a/work/cmplrflags.mk
 +++ b/work/cmplrflags.mk
 @@ -4,12 +4,12 @@ INCDIRS := -I . -I $(SRCDIR)/prep
@@ -75,7 +75,7 @@ index 50d4603..a38a1ba 100644
    ifeq ($(DEBUG),trace)
       FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
    endif
-@@ -252,44 +248,123 @@ ifeq ($(compiler),intel)
+@@ -252,44 +248,124 @@ ifeq ($(compiler),intel)
    endif
    #
    ifeq ($(MACHINENAME),stampede2)
@@ -124,6 +124,7 @@ index 50d4603..a38a1ba 100644
 -     CFLAGS  := $(INCDIRS) -O3 -DLINUX -xAVX
 +  endif
 +  ifeq ($(MACHINENAME),queenbeeC)
++     PFC     :=  mpiifort
 +     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xCORE-AVX512
 +     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX512
 +     FLIBS   := $(INCDIRS) -xCORE-AVX512
@@ -216,7 +217,7 @@ index 50d4603..a38a1ba 100644
    endif
    #
    #@jasonfleming Added to fix bus error on hatteras@renci
-@@ -305,51 +380,54 @@ ifeq ($(compiler),intel)
+@@ -305,51 +381,54 @@ ifeq ($(compiler),intel)
       DPRE          := $(DPRE) -DADCSWAN
    endif
    IMODS         :=  -I
@@ -293,7 +294,7 @@ index 50d4603..a38a1ba 100644
          FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
       endif
       # jgf20150817: Adding support for spirit.afrl.hpc.mil;
-@@ -362,10 +440,6 @@ ifeq ($(compiler),intel)
+@@ -362,10 +441,6 @@ ifeq ($(compiler),intel)
       # jgf20150420 mike requires that the analyst add netcdf to the softenv
       # with the following on the command line
       # soft add +netcdf-4.1.3-Intel-13.0.0
@@ -304,7 +305,7 @@ index 50d4603..a38a1ba 100644
       ifeq ($(MACHINENAME),killdevil)
          HDF5HOME       :=/nas02/apps/hdf5-1.8.5/lib
          NETCDFHOME     :=/nas02/apps/netcdf-4.1.1
-@@ -384,42 +458,33 @@ endif
+@@ -384,42 +459,33 @@ endif
  #
  # Corbitt 120322:  These flags work on the Notre Dame Athos & Zas
  ifeq ($(compiler),intel-ND)
@@ -357,7 +358,7 @@ index 50d4603..a38a1ba 100644
    CLIBS         :=
    MSGLIBS       :=
    $(warning (INFO) Corresponding machine found in cmplrflags.mk.)
-@@ -428,8 +493,10 @@ ifeq ($(compiler),intel-ND)
+@@ -428,8 +494,10 @@ ifeq ($(compiler),intel-ND)
    else
       MULTIPLE := TRUE
    endif
@@ -369,7 +370,7 @@ index 50d4603..a38a1ba 100644
  # SGI ICE X (e.g. topaz@ERDC) using Intel compilers, added by TCM
  # jgf: Added flags for Thunder@AFRL.
  ifeq ($(compiler),intel-sgi)
-@@ -438,7 +505,7 @@ ifeq ($(compiler),intel-sgi)
+@@ -438,7 +506,7 @@ ifeq ($(compiler),intel-sgi)
    PFC           :=  mpif90
    CC            :=  icc -O2 -no-ipo
    CCBE          :=  icc -O2 -no-ipo
@@ -378,7 +379,7 @@ index 50d4603..a38a1ba 100644
  #  FFLAGS1      :=  $(INCDIRS) -Mextend -g -O0 -traceback
    FFLAGS2       :=  $(FFLAGS1)
    FFLAGS3       :=  $(FFLAGS1) -assume buffered_stdout
-@@ -594,7 +661,7 @@ ifeq ($(compiler),xtintel)
+@@ -594,7 +662,7 @@ ifeq ($(compiler),xtintel)
    PFC           :=  ftn
    CC            :=  cc -O2 -no-ipo
    CCBE          :=  cc -O2 -no-ipo
@@ -387,7 +388,7 @@ index 50d4603..a38a1ba 100644
  #  FFLAGS1      :=  $(INCDIRS) -Mextend -g -O0 -traceback
    FFLAGS2       :=  $(FFLAGS1)
    FFLAGS3       :=  $(FFLAGS1) -assume buffered_stdout
-@@ -726,8 +793,8 @@ ifeq ($(compiler),diamond)
+@@ -726,8 +794,8 @@ ifeq ($(compiler),diamond)
    PPFC          :=  ifort
    FC            :=  ifort
    PFC           :=  ifort
@@ -398,7 +399,7 @@ index 50d4603..a38a1ba 100644
    ifeq ($(DEBUG),full)
       FFLAGS1	:=  $(INCDIRS) -g -O0 -debug -fpe0 -132 -traceback -check all -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK
    endif
-@@ -742,8 +809,8 @@ ifeq ($(compiler),diamond)
+@@ -742,8 +810,8 @@ ifeq ($(compiler),diamond)
    IMODS         :=  -I
    CC            := icc
    CCBE          := $(CC)
@@ -409,7 +410,7 @@ index 50d4603..a38a1ba 100644
    ifeq ($(DEBUG),full)
       CFLAGS        := $(INCDIRS) -g -O0
    endif
-@@ -819,7 +886,7 @@ ifeq ($(compiler),kraken)
+@@ -819,7 +887,7 @@ ifeq ($(compiler),kraken)
    PPFC          :=  ftn
    FC            :=  ftn
    PFC           :=  ftn
@@ -418,7 +419,7 @@ index 50d4603..a38a1ba 100644
    FFLAGS2       :=  $(FFLAGS1)
    FFLAGS3       :=  $(FFLAGS1)
    DA            :=  -DREAL8 -DLINUX -DCSCA -DPOWELL
-@@ -869,8 +936,7 @@ ifeq ($(compiler),circleci)
+@@ -869,8 +937,7 @@ ifeq ($(compiler),circleci)
       MULTIPLE := TRUE
    endif
  endif
@@ -428,7 +429,7 @@ index 50d4603..a38a1ba 100644
  #$(MACHINE)
  ########################################################################
  # Compiler flags for Linux operating system on 32bit x86 CPU
-@@ -998,69 +1064,6 @@ ifeq ($(compiler),gnu)
+@@ -998,69 +1065,6 @@ ifeq ($(compiler),gnu)
    endif
  endif
  #
@@ -498,7 +499,7 @@ index 50d4603..a38a1ba 100644
  endif
  
  ########################################################################
-@@ -1105,7 +1108,7 @@ ifeq ($(arch),altix)
+@@ -1105,7 +1109,7 @@ ifeq ($(arch),altix)
    PPFC            := ifort
    FC              := ifort
    PFC             := ifort
@@ -507,7 +508,7 @@ index 50d4603..a38a1ba 100644
    FFLAGS2	  := $(FFLAGS1)
    FFLAGS3	  := $(FFLAGS1)
    DA	          :=  -DREAL8 -DCSCA
-@@ -1178,7 +1181,7 @@ ifeq ($(IBM),p5)
+@@ -1178,7 +1182,7 @@ ifeq ($(IBM),p5)
    FFLAGS0       := $(INCDIRS) -w -qfixed=132 -qarch=auto -qcache=auto
    FFLAGS1       := $(FFLAGS0) -O2
    FFLAGS2       := $(FFLAGS0) -qhot -qstrict
@@ -516,7 +517,7 @@ index 50d4603..a38a1ba 100644
    DA            := -WF,"-DREAL8,-DIBM,-DCSCA"
    DP            := -tF -WF,"-DREAL8,-DIBM,-DCSCA,-DCMPI"
    DPRE          := -tF -WF,"-DREAL8,-DIBM"
-@@ -1498,9 +1501,9 @@ ifneq (,$(findstring powerpc-darwin,$(MACHINE)-$(OS)))
+@@ -1498,9 +1502,9 @@ ifneq (,$(findstring powerpc-darwin,$(MACHINE)-$(OS)))
    PPFC	        := f90
    FC	        := f90
    PFC	        := mpif77
@@ -529,7 +530,7 @@ index 50d4603..a38a1ba 100644
    DA  	   	:=  -DREAL8 -DCSCA -DLINUX
    DP  	   	:=  -DREAL8 -DCSCA -DCMPI -DLINUX
    DPRE	   	:=  -DREAL8 -DLINUX
-@@ -1528,17 +1531,17 @@ ifneq (,$(findstring i386-darwin,$(MACHINE)-$(OS)))
+@@ -1528,17 +1532,17 @@ ifneq (,$(findstring i386-darwin,$(MACHINE)-$(OS)))
    PPFC	        := ifort
    FC	        := ifort
    PFC	        := mpif77

--- a/patches/ADCIRC/v55.02/01-cmplrflags-mk.patch
+++ b/patches/ADCIRC/v55.02/01-cmplrflags-mk.patch
@@ -1,5 +1,5 @@
 diff --git a/work/cmplrflags.mk b/work/cmplrflags.mk
-index 50d4603..a38a1ba 100644
+index 50d4603..c3d4a2b 100644
 --- a/work/cmplrflags.mk
 +++ b/work/cmplrflags.mk
 @@ -4,12 +4,12 @@ INCDIRS := -I . -I $(SRCDIR)/prep
@@ -75,7 +75,7 @@ index 50d4603..a38a1ba 100644
    ifeq ($(DEBUG),trace)
       FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
    endif
-@@ -252,44 +248,123 @@ ifeq ($(compiler),intel)
+@@ -252,44 +248,124 @@ ifeq ($(compiler),intel)
    endif
    #
    ifeq ($(MACHINENAME),stampede2)
@@ -124,6 +124,7 @@ index 50d4603..a38a1ba 100644
 -     CFLAGS  := $(INCDIRS) -O3 -DLINUX -xAVX
 +  endif
 +  ifeq ($(MACHINENAME),queenbeeC)
++     PFC     :=  mpiifort
 +     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xCORE-AVX512
 +     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX512
 +     FLIBS   := $(INCDIRS) -xCORE-AVX512
@@ -216,7 +217,7 @@ index 50d4603..a38a1ba 100644
    endif
    #
    #@jasonfleming Added to fix bus error on hatteras@renci
-@@ -305,51 +380,54 @@ ifeq ($(compiler),intel)
+@@ -305,51 +381,54 @@ ifeq ($(compiler),intel)
       DPRE          := $(DPRE) -DADCSWAN
    endif
    IMODS         :=  -I
@@ -293,7 +294,7 @@ index 50d4603..a38a1ba 100644
          FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
       endif
       # jgf20150817: Adding support for spirit.afrl.hpc.mil;
-@@ -362,10 +440,6 @@ ifeq ($(compiler),intel)
+@@ -362,10 +441,6 @@ ifeq ($(compiler),intel)
       # jgf20150420 mike requires that the analyst add netcdf to the softenv
       # with the following on the command line
       # soft add +netcdf-4.1.3-Intel-13.0.0
@@ -304,7 +305,7 @@ index 50d4603..a38a1ba 100644
       ifeq ($(MACHINENAME),killdevil)
          HDF5HOME       :=/nas02/apps/hdf5-1.8.5/lib
          NETCDFHOME     :=/nas02/apps/netcdf-4.1.1
-@@ -384,42 +458,33 @@ endif
+@@ -384,42 +459,33 @@ endif
  #
  # Corbitt 120322:  These flags work on the Notre Dame Athos & Zas
  ifeq ($(compiler),intel-ND)
@@ -357,7 +358,7 @@ index 50d4603..a38a1ba 100644
    CLIBS         :=
    MSGLIBS       :=
    $(warning (INFO) Corresponding machine found in cmplrflags.mk.)
-@@ -428,8 +493,10 @@ ifeq ($(compiler),intel-ND)
+@@ -428,8 +494,10 @@ ifeq ($(compiler),intel-ND)
    else
       MULTIPLE := TRUE
    endif
@@ -369,7 +370,7 @@ index 50d4603..a38a1ba 100644
  # SGI ICE X (e.g. topaz@ERDC) using Intel compilers, added by TCM
  # jgf: Added flags for Thunder@AFRL.
  ifeq ($(compiler),intel-sgi)
-@@ -438,7 +505,7 @@ ifeq ($(compiler),intel-sgi)
+@@ -438,7 +506,7 @@ ifeq ($(compiler),intel-sgi)
    PFC           :=  mpif90
    CC            :=  icc -O2 -no-ipo
    CCBE          :=  icc -O2 -no-ipo
@@ -378,7 +379,7 @@ index 50d4603..a38a1ba 100644
  #  FFLAGS1      :=  $(INCDIRS) -Mextend -g -O0 -traceback
    FFLAGS2       :=  $(FFLAGS1)
    FFLAGS3       :=  $(FFLAGS1) -assume buffered_stdout
-@@ -594,7 +661,7 @@ ifeq ($(compiler),xtintel)
+@@ -594,7 +662,7 @@ ifeq ($(compiler),xtintel)
    PFC           :=  ftn
    CC            :=  cc -O2 -no-ipo
    CCBE          :=  cc -O2 -no-ipo
@@ -387,7 +388,7 @@ index 50d4603..a38a1ba 100644
  #  FFLAGS1      :=  $(INCDIRS) -Mextend -g -O0 -traceback
    FFLAGS2       :=  $(FFLAGS1)
    FFLAGS3       :=  $(FFLAGS1) -assume buffered_stdout
-@@ -726,8 +793,8 @@ ifeq ($(compiler),diamond)
+@@ -726,8 +794,8 @@ ifeq ($(compiler),diamond)
    PPFC          :=  ifort
    FC            :=  ifort
    PFC           :=  ifort
@@ -398,7 +399,7 @@ index 50d4603..a38a1ba 100644
    ifeq ($(DEBUG),full)
       FFLAGS1	:=  $(INCDIRS) -g -O0 -debug -fpe0 -132 -traceback -check all -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK
    endif
-@@ -742,8 +809,8 @@ ifeq ($(compiler),diamond)
+@@ -742,8 +810,8 @@ ifeq ($(compiler),diamond)
    IMODS         :=  -I
    CC            := icc
    CCBE          := $(CC)
@@ -409,7 +410,7 @@ index 50d4603..a38a1ba 100644
    ifeq ($(DEBUG),full)
       CFLAGS        := $(INCDIRS) -g -O0
    endif
-@@ -819,7 +886,7 @@ ifeq ($(compiler),kraken)
+@@ -819,7 +887,7 @@ ifeq ($(compiler),kraken)
    PPFC          :=  ftn
    FC            :=  ftn
    PFC           :=  ftn
@@ -418,7 +419,7 @@ index 50d4603..a38a1ba 100644
    FFLAGS2       :=  $(FFLAGS1)
    FFLAGS3       :=  $(FFLAGS1)
    DA            :=  -DREAL8 -DLINUX -DCSCA -DPOWELL
-@@ -869,8 +936,7 @@ ifeq ($(compiler),circleci)
+@@ -869,8 +937,7 @@ ifeq ($(compiler),circleci)
       MULTIPLE := TRUE
    endif
  endif
@@ -428,7 +429,7 @@ index 50d4603..a38a1ba 100644
  #$(MACHINE)
  ########################################################################
  # Compiler flags for Linux operating system on 32bit x86 CPU
-@@ -998,69 +1064,6 @@ ifeq ($(compiler),gnu)
+@@ -998,69 +1065,6 @@ ifeq ($(compiler),gnu)
    endif
  endif
  #
@@ -498,7 +499,7 @@ index 50d4603..a38a1ba 100644
  endif
  
  ########################################################################
-@@ -1105,7 +1108,7 @@ ifeq ($(arch),altix)
+@@ -1105,7 +1109,7 @@ ifeq ($(arch),altix)
    PPFC            := ifort
    FC              := ifort
    PFC             := ifort
@@ -507,7 +508,7 @@ index 50d4603..a38a1ba 100644
    FFLAGS2	  := $(FFLAGS1)
    FFLAGS3	  := $(FFLAGS1)
    DA	          :=  -DREAL8 -DCSCA
-@@ -1178,7 +1181,7 @@ ifeq ($(IBM),p5)
+@@ -1178,7 +1182,7 @@ ifeq ($(IBM),p5)
    FFLAGS0       := $(INCDIRS) -w -qfixed=132 -qarch=auto -qcache=auto
    FFLAGS1       := $(FFLAGS0) -O2
    FFLAGS2       := $(FFLAGS0) -qhot -qstrict
@@ -516,7 +517,7 @@ index 50d4603..a38a1ba 100644
    DA            := -WF,"-DREAL8,-DIBM,-DCSCA"
    DP            := -tF -WF,"-DREAL8,-DIBM,-DCSCA,-DCMPI"
    DPRE          := -tF -WF,"-DREAL8,-DIBM"
-@@ -1498,9 +1501,9 @@ ifneq (,$(findstring powerpc-darwin,$(MACHINE)-$(OS)))
+@@ -1498,9 +1502,9 @@ ifneq (,$(findstring powerpc-darwin,$(MACHINE)-$(OS)))
    PPFC	        := f90
    FC	        := f90
    PFC	        := mpif77
@@ -529,7 +530,7 @@ index 50d4603..a38a1ba 100644
    DA  	   	:=  -DREAL8 -DCSCA -DLINUX
    DP  	   	:=  -DREAL8 -DCSCA -DCMPI -DLINUX
    DPRE	   	:=  -DREAL8 -DLINUX
-@@ -1528,17 +1531,17 @@ ifneq (,$(findstring i386-darwin,$(MACHINE)-$(OS)))
+@@ -1528,17 +1532,17 @@ ifneq (,$(findstring i386-darwin,$(MACHINE)-$(OS)))
    PPFC	        := ifort
    FC	        := ifort
    PFC	        := mpif77

--- a/patches/ADCIRC/v56.0.2/01-cmplrflags-mk.patch
+++ b/patches/ADCIRC/v56.0.2/01-cmplrflags-mk.patch
@@ -1,5 +1,5 @@
 diff --git a/work/cmplrflags.mk b/work/cmplrflags.mk
-index 9f89de7..2a550f0 100644
+index 9f89de7..2686918 100644
 --- a/work/cmplrflags.mk
 +++ b/work/cmplrflags.mk
 @@ -1,5 +1,46 @@
@@ -105,7 +105,7 @@ index 9f89de7..2a550f0 100644
    FFLAGS2	:=  $(FFLAGS1)
    FFLAGS3	:=  $(FFLAGS1)
    DA		:=  -DREAL8 -DLINUX -DCSCA
-@@ -189,72 +222,174 @@ endif
+@@ -189,72 +222,175 @@ endif
  # jgf: The -i-dynamic flag defers the inclusion of the library with
  # feupdateenv until run time, thus avoiding the error message:
  # "feupdateenv is not implemented and will always fail"
@@ -191,6 +191,7 @@ index 9f89de7..2a550f0 100644
 -     FFLAGS1 := $(INCDIRS) -O3 -FI -assume byterecl -132 -xAVX -assume buffered_io
 -     CFLAGS  := $(INCDIRS) -O3 -DLINUX -xAVX
 +  ifeq ($(MACHINENAME),queenbeeC)
++     PFC     :=  mpiifort
 +     FFLAGS1 := $(INCDIRS) -O2 -assume byterecl -132 -xCORE-AVX512
 +     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX512
 +     FLIBS   := $(INCDIRS) -xCORE-AVX512
@@ -308,7 +309,7 @@ index 9f89de7..2a550f0 100644
    #
    #@jasonfleming Added to fix bus error on hatteras@renci
    ifeq ($(HEAP_ARRAYS),fix)
-@@ -269,51 +404,60 @@ ifeq ($(compiler),intel)
+@@ -269,51 +405,60 @@ ifeq ($(compiler),intel)
       DPRE          := $(DPRE) -DADCSWAN
    endif
    IMODS         :=  -I
@@ -391,7 +392,7 @@ index 9f89de7..2a550f0 100644
          FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
       endif
       # jgf20150817: Adding support for spirit.afrl.hpc.mil;
-@@ -326,25 +470,12 @@ ifeq ($(compiler),intel)
+@@ -326,25 +471,12 @@ ifeq ($(compiler),intel)
       # jgf20150420 mike requires that the analyst add netcdf to the softenv
       # with the following on the command line
       # soft add +netcdf-4.1.3-Intel-13.0.0
@@ -417,7 +418,7 @@ index 9f89de7..2a550f0 100644
    #jgf20110519: For netcdf on topsail at UNC, use
    #NETCDFHOME=/ifs1/apps/netcdf/
    $(warning (INFO) Corresponding machine found in cmplrflags.mk.)
-@@ -354,62 +485,36 @@ ifeq ($(compiler),intel)
+@@ -354,62 +486,36 @@ ifeq ($(compiler),intel)
       MULTIPLE := TRUE
    endif
  endif
@@ -491,7 +492,7 @@ index 9f89de7..2a550f0 100644
    CLIBS         :=
    MSGLIBS       :=
    $(warning (INFO) Corresponding machine found in cmplrflags.mk.)
-@@ -418,23 +523,24 @@ ifeq ($(compiler),intel-ND)
+@@ -418,23 +524,24 @@ ifeq ($(compiler),intel-ND)
    else
       MULTIPLE := TRUE
    endif
@@ -521,7 +522,7 @@ index 9f89de7..2a550f0 100644
    DPRE          :=  -DREAL8 -DLINUX
    CFLAGS        :=  $(INCDIRS) -DLINUX
    IMODS         :=  -module
-@@ -474,8 +580,8 @@ ifeq ($(compiler),cray_xt3)
+@@ -474,8 +581,8 @@ ifeq ($(compiler),cray_xt3)
    FFLAGS2	:=  $(FFLAGS1)
    FFLAGS3	:=  $(FFLAGS1) -r8 -Mr8 -Mr8intrinsics
    DA  	        :=  -DREAL8 -DLINUX -DCSCA
@@ -532,7 +533,7 @@ index 9f89de7..2a550f0 100644
    DPRE	        :=  -DREAL8 -DLINUX
    CFLAGS	:=  -c89 $(INCDIRS) -DLINUX
    IMODS		:=  -module
-@@ -512,7 +618,7 @@ ifeq ($(compiler),cray_xt4)
+@@ -512,7 +619,7 @@ ifeq ($(compiler),cray_xt4)
    FFLAGS2	:=  $(FFLAGS1)
    FFLAGS3	:=  $(FFLAGS1) -r8 -Mr8 -Mr8intrinsics
    DA  	        :=  -DREAL8 -DLINUX -DCSCA
@@ -541,7 +542,7 @@ index 9f89de7..2a550f0 100644
    DPRE	        :=  -DREAL8 -DLINUX
    ifeq ($(SWAN),enable)
       DPRE	        :=  -DREAL8 -DLINUX -DADCSWAN
-@@ -556,7 +662,7 @@ ifeq ($(compiler),cray_xt5)
+@@ -556,7 +663,7 @@ ifeq ($(compiler),cray_xt5)
    FFLAGS2	:=  $(FFLAGS1)
    FFLAGS3	:=  $(FFLAGS1) -r8 -Mr8 -Mr8intrinsics
    DA  	        :=  -DREAL8 -DLINUX -DCSCA
@@ -550,7 +551,7 @@ index 9f89de7..2a550f0 100644
    DPRE	        :=  -DREAL8 -DLINUX
    CFLAGS	:=  -c89 $(INCDIRS) -DLINUX
    IMODS		:=  -module
-@@ -585,12 +691,12 @@ ifeq ($(compiler),xtintel)
+@@ -585,12 +692,12 @@ ifeq ($(compiler),xtintel)
    PFC           :=  ftn
    CC            :=  cc -O2 -no-ipo
    CCBE          :=  cc -O2 -no-ipo
@@ -565,7 +566,7 @@ index 9f89de7..2a550f0 100644
    DPRE          :=  -DREAL8 -DLINUX
    CFLAGS        :=  $(INCDIRS) -DLINUX
    IMODS         :=  -module
-@@ -652,7 +758,7 @@ ifeq ($(compiler),utils)
+@@ -652,7 +759,7 @@ ifeq ($(compiler),utils)
    FFLAGS2       :=  $(FFLAGS1)
    FFLAGS3       :=  $(FFLAGS1) -r8 -Mr8 -Mr8intrinsics
    DA            :=  -DREAL8 -DLINUX -DCSCA
@@ -574,7 +575,7 @@ index 9f89de7..2a550f0 100644
    DPRE          :=  -DREAL8 -DLINUX
    ifeq ($(SWAN),enable)
       DPRE               :=  -DREAL8 -DLINUX -DADCSWAN
-@@ -717,15 +823,15 @@ ifeq ($(compiler),diamond)
+@@ -717,15 +824,15 @@ ifeq ($(compiler),diamond)
    PPFC          :=  ifort
    FC            :=  ifort
    PFC           :=  ifort
@@ -593,7 +594,7 @@ index 9f89de7..2a550f0 100644
    DPRE          :=  -DREAL8 -DLINUX
    ifeq ($(SWAN),enable)
       DPRE          :=  -DREAL8 -DLINUX -DADCSWAN
-@@ -733,8 +839,8 @@ ifeq ($(compiler),diamond)
+@@ -733,8 +840,8 @@ ifeq ($(compiler),diamond)
    IMODS         :=  -I
    CC            := icc
    CCBE          := $(CC)
@@ -604,7 +605,7 @@ index 9f89de7..2a550f0 100644
    ifeq ($(DEBUG),full)
       CFLAGS        := $(INCDIRS) -g -O0
    endif
-@@ -775,7 +881,7 @@ ifeq ($(compiler),garnet)
+@@ -775,7 +882,7 @@ ifeq ($(compiler),garnet)
    FFLAGS2	:=  $(FFLAGS1)
    FFLAGS3	:=  $(FFLAGS1) #-r8 -Mr8 -Mr8intrinsics
    DA  	        :=  -DREAL8 -DLINUX -DCSCA
@@ -613,7 +614,7 @@ index 9f89de7..2a550f0 100644
    DPRE	        :=  -DREAL8 -DLINUX
    ifeq ($(SWAN),enable)
       DPRE	        :=  -DREAL8 -DLINUX -DADCSWAN
-@@ -810,7 +916,7 @@ ifeq ($(compiler),kraken)
+@@ -810,7 +917,7 @@ ifeq ($(compiler),kraken)
    PPFC          :=  ftn
    FC            :=  ftn
    PFC           :=  ftn
@@ -622,7 +623,7 @@ index 9f89de7..2a550f0 100644
    FFLAGS2       :=  $(FFLAGS1)
    FFLAGS3       :=  $(FFLAGS1)
    DA            :=  -DREAL8 -DLINUX -DCSCA -DPOWELL
-@@ -834,24 +940,24 @@ endif
+@@ -834,24 +941,24 @@ endif
  #
  # Compiler Flags for CircleCI Build Server
  ifeq ($(compiler),circleci)
@@ -654,7 +655,7 @@ index 9f89de7..2a550f0 100644
    endif
    $(warning (INFO) Corresponding compilers and flags found in cmplrflags.mk.)
    ifneq ($(FOUND),TRUE)
-@@ -860,8 +966,7 @@ ifeq ($(compiler),circleci)
+@@ -860,8 +967,7 @@ ifeq ($(compiler),circleci)
       MULTIPLE := TRUE
    endif
  endif
@@ -664,7 +665,7 @@ index 9f89de7..2a550f0 100644
  #$(MACHINE)
  ########################################################################
  # Compiler flags for Linux operating system on 32bit x86 CPU
-@@ -908,7 +1013,7 @@ endif
+@@ -908,7 +1014,7 @@ endif
  ifeq ($(compiler),intel)
    PPFC	        :=  ifort -w
    FC	        :=  ifort -w
@@ -673,7 +674,7 @@ index 9f89de7..2a550f0 100644
    OPTLVL        := -O2
    ifeq ($(ADC_DEBUG),yes)
      OPTLVL        := -g
-@@ -917,7 +1022,7 @@ ifeq ($(compiler),intel)
+@@ -917,7 +1023,7 @@ ifeq ($(compiler),intel)
    FFLAGS2	:=  $(FFLAGS1)
    FFLAGS3	:=  $(FFLAGS1)
    DA  	        :=  -DREAL8 -DLINUX -DCSCA
@@ -682,7 +683,7 @@ index 9f89de7..2a550f0 100644
    DPRE	        :=  -DREAL8 -DLINUX
    IMODS 	:=  -I
    CC            := icc
-@@ -989,69 +1094,6 @@ ifeq ($(compiler),gnu)
+@@ -989,69 +1095,6 @@ ifeq ($(compiler),gnu)
    endif
  endif
  #
@@ -752,7 +753,7 @@ index 9f89de7..2a550f0 100644
  endif
  
  ########################################################################
-@@ -1096,7 +1138,7 @@ ifeq ($(arch),altix)
+@@ -1096,7 +1139,7 @@ ifeq ($(arch),altix)
    PPFC            := ifort
    FC              := ifort
    PFC             := ifort
@@ -761,7 +762,7 @@ index 9f89de7..2a550f0 100644
    FFLAGS2	  := $(FFLAGS1)
    FFLAGS3	  := $(FFLAGS1)
    DA	          :=  -DREAL8 -DCSCA
-@@ -1169,7 +1211,7 @@ ifeq ($(IBM),p5)
+@@ -1169,7 +1212,7 @@ ifeq ($(IBM),p5)
    FFLAGS0       := $(INCDIRS) -w -qfixed=132 -qarch=auto -qcache=auto
    FFLAGS1       := $(FFLAGS0) -O2
    FFLAGS2       := $(FFLAGS0) -qhot -qstrict
@@ -770,7 +771,7 @@ index 9f89de7..2a550f0 100644
    DA            := -WF,"-DREAL8,-DIBM,-DCSCA"
    DP            := -tF -WF,"-DREAL8,-DIBM,-DCSCA,-DCMPI"
    DPRE          := -tF -WF,"-DREAL8,-DIBM"
-@@ -1489,9 +1531,9 @@ ifneq (,$(findstring powerpc-darwin,$(MACHINE)-$(OS)))
+@@ -1489,9 +1532,9 @@ ifneq (,$(findstring powerpc-darwin,$(MACHINE)-$(OS)))
    PPFC	        := f90
    FC	        := f90
    PFC	        := mpif77
@@ -783,7 +784,7 @@ index 9f89de7..2a550f0 100644
    DA  	   	:=  -DREAL8 -DCSCA -DLINUX
    DP  	   	:=  -DREAL8 -DCSCA -DCMPI -DLINUX
    DPRE	   	:=  -DREAL8 -DLINUX
-@@ -1519,17 +1561,17 @@ ifneq (,$(findstring i386-darwin,$(MACHINE)-$(OS)))
+@@ -1519,17 +1562,17 @@ ifneq (,$(findstring i386-darwin,$(MACHINE)-$(OS)))
    PPFC	        := ifort
    FC	        := ifort
    PFC	        := mpif77

--- a/platforms.sh
+++ b/platforms.sh
@@ -107,7 +107,12 @@ init_supermic()
 # propagates in the ASGS Shell environment
 
 init_queenbeeC()
-{ local THIS="platforms.sh>env_dispatch()>init_queenbeeC()"
+{ 
+  # Environment assumed with this ~/.modules file:
+  #    module load intel/19.0.5
+  #    module load intel-mpi/2019.5.281
+  #    module load gcc/8.4.0
+  local THIS="platforms.sh>env_dispatch()>init_queenbeeC()"
   scenarioMessage "$THIS: Setting platforms-specific parameters."
   export HPCENV=qbc.loni.org
   export QUEUESYS=SLURM


### PR DESCRIPTION
Issue 1426: now using mpiifort

Resolves #1424.