### PR TITLE
Setting default compiler for QBD to `intel-oneapi`

### DIFF
--- a/platforms/queenbeeD/init.sh
+++ b/platforms/queenbeeD/init.sh
@@ -13,6 +13,7 @@ export JOBLAUNCHER='srun '
 export SUBMITSTRING=sbatch
 export QSCRIPTTEMPLATE=$SCRIPTDIR/qscript.template
 export QSCRIPTGEN=qscript.pl
+export DEFAULT_COMPILER=intel-oneapi
 export OPENDAPPOST=opendap_post2.sh #<~ $SCRIPTDIR/output/ assumed
 export ARCHIVE=enstorm_pedir_removal.sh
 export ARCHIVEBASE=$SCRATCH


### PR DESCRIPTION
Issue 1435:

Resolves #1435.