### PR TITLE
fix so wgrib2 can compile with chosen compiler

### DIFF
--- a/cloud/general/asgs-brew.pl
+++ b/cloud/general/asgs-brew.pl
@@ -827,7 +827,7 @@ sub get_steps {
             name        => q{Step for wgrib2},
             description => q{Downloads and builds wgrib2 on all platforms for ASGS. Note: gfortran is required, so any compiler option passed is overridden.},
             pwd         => qq{$scriptdir},
-	    command             => qq{bash init-wgrib2.sh $asgs_install_path gfortran},
+	    command             => qq{bash init-wgrib2.sh $asgs_install_path $asgs_compiler},
 	    clean               => qq{bash init-wgrib2.sh $asgs_install_path clean},
             skip_if             => sub { my ( $op, $opts_ref ) = @_; return -e qq{./bin/wgrib2}; },
             precondition_check  => sub { 1 },

--- a/cloud/general/init-perl-data-language.sh
+++ b/cloud/general/init-perl-data-language.sh
@@ -12,4 +12,4 @@ if [[ "$COMPILER" == "clean" || "$COMPILER" == "rebuild" ]]; then
   fi
 fi
 
-cpanm --verbose PDL
+cpanm --verbose PDL@2.099

--- a/cloud/general/init-wgrib2.sh
+++ b/cloud/general/init-wgrib2.sh
@@ -22,10 +22,28 @@ rm -rf grib2 > /dev/null 2>&1
 tar zxvf wgrib2${VERSION}.tgz > /dev/null 2>&1
 
 pwd
-make -j 1 NETCDFPATH=$asgs_install_path NETCDF=enable NETCDF4=enable NETCDF4_COMPRESSION=enable MACHINE_NAME=$asgs_machine_name compiler=$COMPILER
+
+if [ "$compiler" == "intel" ]; then
+  CC=gcc
+  FC=gfortran
+  COMP_SYS=gnu_linux
+fi
+if [ "$compiler" == "intel" ]; then
+  CC=icc
+  FC=ifort
+  COMP_SYS=intel_linux
+fi
+if [ "$compiler" == "intel-oneapi" ]; then
+  CC=icc
+  FC=ifort
+  COMP_SYS=intel_linux
+fi
+
+make -j 1 NETCDFPATH=$OPT NETCDF=enable NETCDF4=enable NETCDF4_COMPRESSION=enable MACHINE_NAME=$ASGS_MACHINE_NAME compiler=$COMPILER
+
 cp $SCRIPTDIR/grib2/wgrib2/wgrib2 $SCRIPTDIR/bin > /dev/null 2>&1
 
-rm -rfv grib2
-rm -fv  wgrib2${VERSION}.tgz
+#rm -rfv grib2
+#rm -fv  wgrib2${VERSION}.tgz
 
 popd

--- a/cloud/general/init-wgrib2.sh
+++ b/cloud/general/init-wgrib2.sh
@@ -42,7 +42,7 @@ make -j 1 NETCDFPATH=$OPT NETCDF=enable NETCDF4=enable NETCDF4_COMPRESSION=enabl
 
 cp $SCRIPTDIR/grib2/wgrib2/wgrib2 $SCRIPTDIR/bin > /dev/null 2>&1
 
-#rm -rfv grib2
-#rm -fv  wgrib2-${VERSION}.tgz
+rm -rfv grib2
+rm -fv  wgrib2-${VERSION}.tgz
 
 popd

--- a/cloud/general/init-wgrib2.sh
+++ b/cloud/general/init-wgrib2.sh
@@ -3,25 +3,24 @@
 OPT=${1:-$ASGS_INSTALL_PATH}
 COMPILER=${2:-intel}
 
-VERSION=-3.1.1
+VERSION=3.1.2
 
 if [ $COMPILER == "clean" ]; then
   make clean
   rm -rfv grib2
-  rm -fv  wgrib2${VERSION}.tgz 
+  rm -fv  wgrib2-${VERSION}.tgz 
   exit
 fi
 
 pushd $SCRIPTDIR
 
 if [ ! -e wgrib2${VERSION}.tgz ]; then
-  wget https://asgs-static-assets.sfo2.digitaloceanspaces.com/lib/wgrib2${VERSION}.tgz
+  #wget https://asgs-static-assets.sfo2.digitaloceanspaces.com/lib/wgrib2-${VERSION}.tgz -O wgrib2-${VERSION}.tgz
+  wget https://ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz.v${VERSION} -O wgrib2-${VERSION}.tgz
 fi
 
 rm -rf grib2 > /dev/null 2>&1
-tar zxvf wgrib2${VERSION}.tgz > /dev/null 2>&1
-
-pwd
+tar zxvf wgrib2-${VERSION}.tgz 
 
 if [ "$compiler" == "intel" ]; then
   CC=gcc
@@ -34,9 +33,9 @@ if [ "$compiler" == "intel" ]; then
   COMP_SYS=intel_linux
 fi
 if [ "$compiler" == "intel-oneapi" ]; then
-  CC=icc
-  FC=ifort
-  COMP_SYS=intel_linux
+  CC=icx
+  FC=ifx
+  COMP_SYS=oneapi_linux
 fi
 
 make -j 1 NETCDFPATH=$OPT NETCDF=enable NETCDF4=enable NETCDF4_COMPRESSION=enable MACHINE_NAME=$ASGS_MACHINE_NAME compiler=$COMPILER
@@ -44,6 +43,6 @@ make -j 1 NETCDFPATH=$OPT NETCDF=enable NETCDF4=enable NETCDF4_COMPRESSION=enabl
 cp $SCRIPTDIR/grib2/wgrib2/wgrib2 $SCRIPTDIR/bin > /dev/null 2>&1
 
 #rm -rfv grib2
-#rm -fv  wgrib2${VERSION}.tgz
+#rm -fv  wgrib2-${VERSION}.tgz
 
 popd

--- a/cloud/general/init-wgrib2.sh
+++ b/cloud/general/init-wgrib2.sh
@@ -14,22 +14,18 @@ fi
 
 pushd $SCRIPTDIR
 
-export COMP_SYS=gnu_linux
-export CC=gcc
-export FC=gfortran
-export CXX=g++
-
 if [ ! -e wgrib2${VERSION}.tgz ]; then
   wget https://asgs-static-assets.sfo2.digitaloceanspaces.com/lib/wgrib2${VERSION}.tgz
 fi
 
-rm -rf grib2
-tar zxvf wgrib2${VERSION}.tgz
+rm -rf grib2 > /dev/null 2>&1
+tar zxvf wgrib2${VERSION}.tgz > /dev/null 2>&1
 
-make -j 1 NETCDFPATH=$asgs_install_path NETCDF=enable NETCDF4=enable NETCDF4_COMPRESSION=enable MACHINE_NAME=$asgs_machine_name compiler=gfortran
-cp $SCRIPTDIR/grib2/wgrib2/wgrib2 $SCRIPTDIR/bin
+pwd
+make -j 1 NETCDFPATH=$asgs_install_path NETCDF=enable NETCDF4=enable NETCDF4_COMPRESSION=enable MACHINE_NAME=$asgs_machine_name compiler=$COMPILER
+cp $SCRIPTDIR/grib2/wgrib2/wgrib2 $SCRIPTDIR/bin > /dev/null 2>&1
 
 rm -rfv grib2
-rm -fv  wgrib2${VERSION}.tgz 
+rm -fv  wgrib2${VERSION}.tgz
 
 popd

--- a/makefile
+++ b/makefile
@@ -24,10 +24,12 @@
 #
 # specify compiler=gfortran on the make command line
 
+$(info Compiler: $(compiler))
+
 ifeq ($(compiler),gfortran)
-   export FC := gfortran
-   export CC := gcc
-   export COMP_SYS := gnu_linux
+   override FC := gfortran
+   override CC := gcc
+   override COMP_SYS := gnu_linux
    FFLAGS := -ffree-line-length-none -ffixed-line-length-none
    ifeq ($(DEBUG),full)
       FFLAGS := -cpp -ffree-line-length-none -g -O0 -fbacktrace -fbounds-check -ffpe-trap=zero,invalid,underflow,overflow,denormal #-Wall
@@ -36,9 +38,9 @@ endif
 #
 # specify compiler=intel on the make command line
 ifeq ($(compiler),intel)
-   export FC := ifort
-   export CC := icc
-   export COMP_SYS := intel_linux
+   override FC := ifort
+   override CC := icc
+   override COMP_SYS := intel_linux
    FFLAGS := -132
    ifeq ($(DEBUG),full)
       FFLAGS := -g -O0 -fpp -traceback -debug -check all
@@ -46,23 +48,17 @@ ifeq ($(compiler),intel)
 endif
 # specify compiler=intel on the make command line
 ifeq ($(compiler),intel-oneapi)
-   export FC := ifx
-   export CC := icx
-   export COMP_SYS := oneapi_linux
+   override FC := ifx
+   override CC := icx
+   override COMP_SYS := oneapi_linux
    FFLAGS := -132
    ifeq ($(DEBUG),full)
       FFLAGS := -g -O0 -fpp -traceback -debug -check all
    endif
 endif
-ifeq ($(compiler),intel-oneapi)
-   export FC := ifort
-   export CC := icx
-   export COMP_SYS := intel_linux
-   FFLAGS := -132
-   ifeq ($(DEBUG),full)
-      FFLAGS := -g -O0 -fpp -traceback -debug -check all
-   endif
-endif
+
+$(info FC: $(FC))
+
 #
 INCLUDES :=
 #

--- a/makefile
+++ b/makefile
@@ -26,11 +26,13 @@
 
 $(info Compiler: $(compiler))
 
+export OMP_NUM_THREADS=4
+
 ifeq ($(compiler),gfortran)
-   override FC := gfortran
-   override CC := gcc
-   override COMP_SYS := gnu_linux
-   FFLAGS := -ffree-line-length-none -ffixed-line-length-none
+   export FC := gfortran
+   export CC := gcc
+   export COMP_SYS := gnu_linux
+   FFLAGS := -ffree-line-length-none -ffixed-line-length-none -fopenmp
    ifeq ($(DEBUG),full)
       FFLAGS := -cpp -ffree-line-length-none -g -O0 -fbacktrace -fbounds-check -ffpe-trap=zero,invalid,underflow,overflow,denormal #-Wall
    endif
@@ -38,20 +40,20 @@ endif
 #
 # specify compiler=intel on the make command line
 ifeq ($(compiler),intel)
-   override FC := ifort
-   override CC := icc
-   override COMP_SYS := intel_linux
-   FFLAGS := -132
+   export FC := ifort
+   export CC := icc
+   export COMP_SYS := intel_linux
+   FFLAGS := -132 -qopenmp
    ifeq ($(DEBUG),full)
       FFLAGS := -g -O0 -fpp -traceback -debug -check all
    endif
 endif
 # specify compiler=intel on the make command line
 ifeq ($(compiler),intel-oneapi)
-   override FC := ifx
-   override CC := icx
-   override COMP_SYS := oneapi_linux
-   FFLAGS := -132
+   export FC := ifx
+   export CC := icx
+   export COMP_SYS := oneapi_linux
+   FFLAGS := -132 -qopenmp
    ifeq ($(DEBUG),full)
       FFLAGS := -g -O0 -fpp -traceback -debug -check all
    endif


### PR DESCRIPTION
This is to get wgrib2 to compile properly without `gfortran`. I thought I had fixed this once before, so I went back and looked. It was being forced to compile with gfortran, something I probably did either in a pinch or it was a regression from merging an old branch. In either case, I think I am close to make sure that wgrib2 can compile with compiler "family" that everything else is compiled with, i.e., "gfortran" (GNU compilers,) "intel" (icc, ifort, etc;) or "intel-oneapi" (icx, ifx, etc.).