### PR TITLE
Add v56.0.4 (keep v56.0.2 but add note about deprecation)

### DIFF
--- a/bin/init-adcirc.sh
+++ b/bin/init-adcirc.sh
@@ -64,6 +64,8 @@ _is_a_num()
 # This function is just to support the menu that comes up when the utility is run
 _show_supported_versions()
 {
+  echo
+  printf "/## ASGS ADCIRC Builder ##############\ \n"
   local num=0
   _ADCIRCS=
   for VERSION in $(ls -1 $SCRIPTDIR/patches/ADCIRC); do
@@ -90,11 +92,12 @@ _show_supported_versions()
   fi
   # final menu entry for custom directory
   num=$(($num+1))
-  printf "%2s. %-33s | %-66s\n" $num custom "(*) select this option for custom directory"
+  printf "%2s. %-33s | %-66s\n" $num custom "select this option for custom directory *,**"
   num=$(($num+1))
   printf "%2s. %-33s | %-66s\n" $num quit "type 'quit', 'q', or 'ctrl-c' to quit"
   echo  "--"
-  echo "* Contact <help@support.adcirc.live> if additional ADCIRC version supported is required."
+  echo "* Contact <help@support.adcirc.live> if privately patched ADCIRC support is required."
+  echo "** See more about ADCIRC version support options at https://tools.adcirc.live/install"
   echo
   ADCIRCS=($_ADCIRCS custom)
   if [ "${1}" != "noexit" ]; then

--- a/patches/ADCIRC/v53release/about.txt
+++ b/patches/ADCIRC/v53release/about.txt
@@ -1,1 +1,1 @@
-latest upstream v53.05 + adcprep "--prep13" fix
+(default) latest upstream v53.05 + adcprep "--prep13" fix

--- a/patches/ADCIRC/v56.0.2/about.txt
+++ b/patches/ADCIRC/v56.0.2/about.txt
@@ -1,1 +1,1 @@
-upstream release version v56.0.2
+(deprecating) upstream release version v56.0.2

--- a/patches/ADCIRC/v56.0.4/01-cmplrflags-mk.patch
+++ b/patches/ADCIRC/v56.0.4/01-cmplrflags-mk.patch
@@ -1,0 +1,809 @@
+diff --git a/work/cmplrflags.mk b/work/cmplrflags.mk
+index 9f89de7..2686918 100644
+--- a/work/cmplrflags.mk
++++ b/work/cmplrflags.mk
+@@ -1,5 +1,46 @@
+ # SRCDIR is set in makefile or on the compile line
+-INCDIRS := -I. -I$(SRCDIR)/prep
++INCDIRS := -I . -I $(SRCDIR)/prep
++
++########################################################################
++# Compiler flags for Linux operating system on 64bit x86 CPU
++#
++ifeq ($(MACHINE)-$(OS),i686-mingw32)
++#
++# ***NOTE*** User must select between various Linux setups
++#            by commenting/uncommenting the appropriate compiler
++#
++compiler=gnu
++ifeq ($(compiler),gnu)
++  PPFC		:=  gfortran
++  FC		:=  gfortran
++  PFC		:=  mpif90
++  FFLAGS1	:=  $(INCDIRS) -O2 -mcmodel=medium -ffixed-line-length-none -march=corei7-avx -m64 -static
++  FFLAGS2	:=  $(FFLAGS1)
++  FFLAGS3	:=  $(FFLAGS1)
++  DA		:=  -DREAL8 -DLINUX -DCSCA
++  DP		:=  -DREAL8 -DLINUX -DCSCA -DCMPI -DHAVE_MPI_MOD
++  DPRE		:=  -DREAL8 -DLINUX
++  IMODS 	:=  -I
++  CC		:= gcc
++  CCBE		:= $(CC)
++  CFLAGS	:= $(INCDIRS) -O2 -mcmodel=medium -DLINUX -march=corei7-avx -m64 -static-libgcc
++  CLIBS	:=
++  LIBS		:=
++  MSGLIBS	:=
++  ifeq ($(NETCDF),enable)
++        FLIBS          := $(FLIBS) -L$(HDF5HOME) -lhdf5 -lhdf5_fortran
++  endif
++  $(warning (INFO) Corresponding compilers and flags found in cmplrflags.mk.)
++  ifneq ($(FOUND),TRUE)
++     FOUND := TRUE
++  else
++     MULTIPLE := TRUE
++  endif
++endif
++endif
++#$(MACHINE)
++
++
+ 
+ ########################################################################
+ # Compiler flags for Linux operating system on 64bit x86 CPU
+@@ -33,28 +74,25 @@ ifeq ($(compiler),gnu)
+   PPFC		:=  gfortran
+   FC		:=  gfortran
+   PFC		:=  mpif90
+-  FFLAGS1	:=  $(INCDIRS) -O2 -mcmodel=medium -ffixed-line-length-none -m64
++  FFLAGS1	:=  $(INCDIRS) -O2 -mcmodel=medium -ffixed-line-length-none -march=k8 -m64
+   FFLAGS2	:=  $(FFLAGS1)
+   FFLAGS3	:=  $(FFLAGS1)
+   DA		:=  -DREAL8 -DLINUX -DCSCA
+-  DP		:=  -DREAL8 -DLINUX -DCSCA -DCMPI 
++  DP		:=  -DREAL8 -DLINUX -DCSCA -DCMPI -DHAVE_MPI_MOD
+   DPRE		:=  -DREAL8 -DLINUX
+   IMODS 	:=  -I
+   CC		:= gcc
+   CCBE		:= $(CC)
+-  CFLAGS	:= $(INCDIRS) -O2 -mcmodel=medium -DLINUX -m64
++  CFLAGS	:= $(INCDIRS) -O2 -mcmodel=medium -DLINUX -march=k8 -m64
+   CLIBS	:=
+   LIBS		:=
+   MSGLIBS	:=
+   ifeq ($(NETCDF),enable)
+      ifeq ($(MACHINENAME),blueridge)
+         # FLIBS       := $(FLIBS) -L$(HDF5HOME) -lhdf5
+-        NETCDFHOME    :=/usr
+         FFLAGS1       :=$(FFLAGS1) -I/usr/lib64/gfortran/modules
+         FFLAGS2       :=$(FFLAGS1)
+         FFLAGS3       :=$(FFLAGS1)
+-        # NETCDFHOME  :=/shared/apps/RHEL-5/x86_64/NetCDF/netcdf-4.1.1-gcc4.1-ifort
+-        # NETCDFHOME  :=/shared/apps/RHEL-5/x86_64/NetCDF/netcdf-4.1.2-gcc4.1-ifort
+         FLIBS          :=$(FLIBS) -L/usr/lib64 -lnetcdff
+      else
+         FLIBS          := $(FLIBS) -L$(HDF5HOME) -lhdf5 -lhdf5_fortran
+@@ -136,12 +174,7 @@ ifeq ($(compiler),gfortran)
+         FFLAGS2 := $(FFLAGS2) -I/usr/lib64/gfortran/modules
+         FFLAGS3 := $(FFLAGS3) -I/usr/lib64/gfortran/modules
+      endif
+-     ifeq ($(MACHINENAME),wsl2-ubuntu)
+-        NETCDFHOME := /usr
+-        FFLAGS1 := $(FFLAGS1) -I/usr/include
+-        FFLAGS2 := $(FFLAGS2) -I/usr/include
+-        FFLAGS3 := $(FFLAGS3) -I/usr/include
+-     endif
++     FLIBS      := $(FLIBS) -lnetcdff
+   endif
+   IMODS 	:=  -I
+   CC		:= gcc
+@@ -164,7 +197,7 @@ ifeq ($(compiler),g95)
+   PPFC		:=  g95
+   FC		:=  g95
+   PFC		:=  mpif90
+-  FFLAGS1	:=  $(INCDIRS) -O3 -mcmodel=medium -fstatic -ffixed-line-length-132
++  FFLAGS1	:=  $(INCDIRS) -O2 -mcmodel=medium -fstatic -ffixed-line-length-132
+   FFLAGS2	:=  $(FFLAGS1)
+   FFLAGS3	:=  $(FFLAGS1)
+   DA		:=  -DREAL8 -DLINUX -DCSCA
+@@ -189,72 +222,175 @@ endif
+ # jgf: The -i-dynamic flag defers the inclusion of the library with
+ # feupdateenv until run time, thus avoiding the error message:
+ # "feupdateenv is not implemented and will always fail"
+-ifeq ($(compiler),intel)
++# this line is to support icc/ifort and icx/ifort (llvm based)
++ifneq (,$(filter intel intel-oneapi,$(compiler)))
++  CC            :=  icc
+   PPFC          :=  ifort
+   FC            :=  ifort
+-  PFC           ?=  mpif90
+-  FFLAGS1       := $(INCDIRS) -O2 -g -traceback -FI -assume byterecl -132 -xSSE4.2 -assume buffered_io
++  PFC           :=  mpif90
++  FFLAGS1       :=  $(INCDIRS) -O2 -assume byterecl -132 -xSSE4.2
+   CFLAGS        := $(INCDIRS) -O2 -xSSE4.2 -m64 -mcmodel=medium -DLINUX
+   FLIBS         :=
+   ifeq ($(DEBUG),full)
+-     CFLAGS        := $(INCDIRS) -g -O0 -m64 -mcmodel=medium -DLINUX
++     CFLAGS        := $(INCDIRS) -g -O0 -march=k8 -m64 -mcmodel=medium -DLINUX
+   endif
+   ifeq ($(DEBUG),full)
+-     FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -debug all -check all -ftrapuv -fpe0 -FI -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
+-  endif
+-  ifeq ($(DEBUG),full-not-fpe)
+-     FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -debug all -check all -FI -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
++     FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -debug all -check all -ftrapuv -fpe0 -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
+   endif
+   ifeq ($(DEBUG),trace)
+-     FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
++     FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
+   endif
+   ifeq ($(DEBUG),buserror)
+-     FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES -check bounds
++     FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES -check bounds
+   endif
+   ifeq ($(DEBUG),netcdf_trace)
+-     FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -DNETCDF_TRACE -DFULL_STACK -DFLUSH_MESSAGES
++     FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -DNETCDF_TRACE -DFULL_STACK -DFLUSH_MESSAGES
+   endif
+   #
+   ifeq ($(MACHINENAME),stampede2)
+-     FFLAGS1 := $(INCDIRS) -O3 -FI -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 -assume buffered_io
+-     CFLAGS  := $(INCDIRS) -O3 -DLINUX -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
++     FFLAGS1 := $(INCDIRS) -O2 -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
+      FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
+      ifeq ($(DEBUG),trace)
+-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 -assume buffered_io
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
+         CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
+         FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
+      endif
+   endif
+-  ifeq ($(MACHINENAME),frontera) 
+-     FFLAGS1 := $(INCDIRS) -O3 -FI -assume byterecl -132 -xCORE-AVX512 -assume buffered_io
+-     CFLAGS  := $(INCDIRS) -O3 -DLINUX -xCORE-AVX512 
+-     FLIBS   := $(INCDIRS) -xCORE-AVX512 
++  ifeq ($(MACHINENAME),frontera)
++     FFLAGS1 := $(INCDIRS) -O2 -assume byterecl -132 -xCORE-AVX512
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX512
++     FLIBS   := $(INCDIRS) -xCORE-AVX512
+      ifeq ($(DEBUG),trace)
+-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX512 -assume buffered_io
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -xCORE-AVX512
+         CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX512
+-        FLIBS   := $(INCDIRS) -xCORE-AVX512 
++        FLIBS   := $(INCDIRS) -xCORE-AVX512
+      endif
+   endif
+   ifeq ($(MACHINENAME),queenbee)
+-     FFLAGS1 := $(INCDIRS) -O3 -FI -assume byterecl -132 -xSSE4.2 -assume buffered_io
+-     CFLAGS  := $(INCDIRS) -O3 -DLINUX -xSSE4.2
++     FFLAGS1 := $(INCDIRS) -O2 -assume byterecl -132 -xSSE4.2
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xSSE4.2
+      FLIBS   := $(INCDIRS) -xSSE4.2
+      ifeq ($(DEBUG),trace)
+-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xSSE4.2 -assume buffered_io
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -xSSE4.2
+         CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xSSE4.2
+         FLIBS   := $(INCDIRS) -xSSE4.2
+      endif
+   endif
+-  ifeq ($(MACHINENAME),supermic) 
+-     FFLAGS1 := $(INCDIRS) -O3 -FI -assume byterecl -132 -xAVX -assume buffered_io
+-     CFLAGS  := $(INCDIRS) -O3 -DLINUX -xAVX
++  ifeq ($(MACHINENAME),queenbeeC)
++     PFC     :=  mpiifort
++     FFLAGS1 := $(INCDIRS) -O2 -assume byterecl -132 -xCORE-AVX512
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX512
++     FLIBS   := $(INCDIRS) -xCORE-AVX512
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -xCORE-AVX512
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX512
++        FLIBS   := $(INCDIRS) -xCORE-AVX512
++     endif
++  endif
++  ifeq ($(MACHINENAME),queenbeeD)
++     PFC     :=  mpiifort
++     FFLAGS1 := $(INCDIRS) -O2 -132
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xAVX
++     FLIBS   := $(INCDIRS) -xAVX
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -xAVX
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX
++        FLIBS   := $(INCDIRS) -xAVX
++     endif
++  endif
++  ifeq ($(MACHINENAME),supermic)
++     PFC     :=  mpiifort
++     FFLAGS1 := $(INCDIRS) -O2 -132
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xAVX
++     FLIBS   := $(INCDIRS) -xAVX
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -xAVX
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX
++        FLIBS   := $(INCDIRS) -xAVX
++     endif
++  endif
++  ifeq ($(MACHINENAME),rostam)
++     FFLAGS1 := $(INCDIRS) -O2 -assume byterecl -132 -xAVX
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xAVX
++     FLIBS   := $(INCDIRS) -xAVX
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -xAVX
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX
++        FLIBS   := $(INCDIRS) -xAVX
++     endif
++  endif
++  ifeq ($(MACHINENAME),ls6)
++     FFLAGS1 := $(INCDIRS) -O2 -assume byterecl -132
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX
++     FLIBS   := $(INCDIRS)
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX
++        FLIBS   := $(INCDIRS)
++     endif
++  endif
++  #wwlwpd: NOTE: Mike III at LSU-HPC recommends 'mpiifort', Intel's MPI implementation wrapper
++  #wwlwpd: instead of the traditional "mpif90"; but the flags are the same we still redefine
++  #wwlwpd: "PFC" below
++  ifeq ($(MACHINENAME),mike)
++     PFC     :=  mpiifort
++     FFLAGS1 := $(INCDIRS) -O2 -assume byterecl -132 -xAVX
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xAVX
+      FLIBS   := $(INCDIRS) -xAVX
+      ifeq ($(DEBUG),trace)
+-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xAVX -assume buffered_io
+-        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX 
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -xAVX
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX
+         FLIBS   := $(INCDIRS) -xAVX
+      endif
+   endif
++  ifeq ($(MACHINENAME),stampede3)
++     CC      := icx
++     FFLAGS1 := $(INCDIRS) -O2 -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX2 -axCORE-AVX512 -Wno-implicit-function-declaration
++     FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512 -Wimplicit-function-declaration
++        FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++     endif
++  endif
++  ifeq ($(MACHINENAME),debian)
++     PFC     := mpiifort
++     CC      := icx
++     FFLAGS1 := $(INCDIRS) -O2 -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX2 -axCORE-AVX512 -Wno-implicit-function-declaration
++     FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512 -Wimplicit-function-declaration
++        FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++     endif
++  endif
++  ifeq ($(MACHINENAME),rhel)
++     PFC     := mpiifort
++     CC      := icx
++     FFLAGS1 := $(INCDIRS) -O2 -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX2 -axCORE-AVX512 -Wno-implicit-function-declaration
++     FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512 -Wimplicit-function-declaration
++        FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++     endif
++  endif
++  ifeq ($(MACHINENAME),centos7)
++     PFC     := mpiifort
++     CC      := icc
++     FFLAGS1 := $(INCDIRS) -O2 -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX2 -axCORE-AVX512 -Wno-implicit-function-declaration
++     FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512 -Wimplicit-function-declaration
++        FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++     endif
++  endif
+   #
+   #@jasonfleming Added to fix bus error on hatteras@renci
+   ifeq ($(HEAP_ARRAYS),fix)
+@@ -269,51 +405,60 @@ ifeq ($(compiler),intel)
+      DPRE          := $(DPRE) -DADCSWAN
+   endif
+   IMODS         :=  -I
+-  CC            := icc
++  #CC            := icc  # get from start of this section
+   CCBE		:= $(CC)
+   CLIBS         :=
+   MSGLIBS       :=
+   ifeq ($(NETCDF),enable)
+-     ifeq ($(MACHINENAME),hatteras)
+-        NETCDFHOME  :=$(shell nf-config --prefix)
+-        FLIBS       :=$(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+-        FFLAGS1     :=$(FFLAGS1) -I$(NETCDFHOME)/include
+-        FFLAGS2     :=$(FFLAGS1)
+-        FFLAGS3     :=$(FFLAGS1)
++     FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      # jgf20150417 queenbee requires that the analyst load the netcdf and
+      # netcdf_fortran modules prior to compiling or executing ADCIRC
+      ifeq ($(MACHINENAME),queenbee)
+-        FLIBS       := $(FLIBS) -L/usr/local/packages/netcdf/4.2.1.1/INTEL-140-MVAPICH2-2.0/lib -lnetcdff -lnetcdf
+-        NETCDFHOME    :=/usr/local/packages/netcdf/4.2.1.1/INTEL-140-MVAPICH2-2.0
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
++     ifeq ($(MACHINENAME),queenbeeC)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
++     ifeq ($(MACHINENAME),queenbeeD)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),supermic)
+-        FLIBS      := $(FLIBS) -L/usr/local/packages/netcdf_fortran/4.2/INTEL-140-MVAPICH2-2.0/lib -lnetcdff -L/usr/local/packages/netcdf/4.2.1.1/INTEL-140-MVAPICH2-2.0/lib -lnetcdf -lnetcdf -liomp5 -lpthread
+-        NETCDFHOME :=/usr/local/packages/netcdf/4.2.1.1/INTEL-140-MVAPICH2-2.0/include
+-        FFLAGS1    :=$(FFLAGS1) -I/usr/local/packages/hdf5/1.8.12/INTEL-140-MVAPICH2-2.0/include
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
++     ifeq ($(MACHINENAME),rostam)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),stampede)
+-        NETCDFHOME :=/opt/apps/intel17/netcdf/4.3.3.1/x86_64
+         FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),stampede2)
+-        NETCDFHOME :=/opt/apps/intel17/netcdf/4.3.3.1/x86_64
+         FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+-        ifeq ($(USER),jgflemin)
+-           NETCDFHOME :=/work/00976/jgflemin/stampede2/local
+-           FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+-        endif
++     endif
++     ifeq ($(MACHINENAME),stampede3)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),frontera)
+-        # specify NETCDFHOME on the command line or as an environment var
+         FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      # @jasonfleming: Added support for lonestar5 at tacc.utexas.edu;
+      # load the following module: netcdf/4.3.3.1
+      ifeq ($(MACHINENAME),lonestar5)
+-        #NETCDFHOME :=/opt/apps/intel18/netcdf/4.3.3.1/x86_64
+-        # @jasonfleming: Updated support for lonestar5
+-        NETCDFHOME :=/opt/apps/intel18/netcdf/4.6.2/x86_64
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
++     ifeq ($(MACHINENAME),ls6)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
++     ifeq ($(MACHINENAME),mike)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
++     ifeq ($(MACHINENAME),debian)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
++     ifeq ($(MACHINENAME),rhel)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
++     ifeq ($(MACHINENAME),centos7)
+         FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      # jgf20150817: Adding support for spirit.afrl.hpc.mil;
+@@ -326,25 +471,12 @@ ifeq ($(compiler),intel)
+      # jgf20150420 mike requires that the analyst add netcdf to the softenv
+      # with the following on the command line
+      # soft add +netcdf-4.1.3-Intel-13.0.0
+-     ifeq ($(MACHINENAME),mike)
+-        FLIBS       := $(FLIBS) -L/usr/local/packages/netcdf/4.1.3/Intel-13.0.0/lib -lnetcdff -lnetcdf
+-        NETCDFHOME    :=/usr/local/packages/netcdf/4.1.3/Intel-13.0.0
+-     endif
+      ifeq ($(MACHINENAME),killdevil)
+         HDF5HOME       :=/nas02/apps/hdf5-1.8.5/lib
+         NETCDFHOME     :=/nas02/apps/netcdf-4.1.1
+         FLIBS          := $(FLIBS) -L$(HDF5HOME) -lhdf5 -lhdf5_fortran
+      endif
+   endif
+-
+-# ------------
+-  ifeq ($(NETCDF),enable)
+-    ifeq ($(WDALTVAL),enable)
+-       DP  := $(DP) -DWDVAL_NETCDF 
+-    endif
+-  endif
+-# -----------
+-
+   #jgf20110519: For netcdf on topsail at UNC, use
+   #NETCDFHOME=/ifs1/apps/netcdf/
+   $(warning (INFO) Corresponding machine found in cmplrflags.mk.)
+@@ -354,62 +486,36 @@ ifeq ($(compiler),intel)
+      MULTIPLE := TRUE
+   endif
+ endif
+-
+ #
+ # Corbitt 120322:  These flags work on the Notre Dame Athos & Zas
+ ifeq ($(compiler),intel-ND)
+-  PPFC          :=  ifort
++  PPFC            :=  ifort
+   FC            :=  ifort
+-  PFC           ?=  mpif90
+-#  FFLAGS1       :=  $(INCDIRS) -w -O3 -assume byterecl -132 -assume buffered_io #-i-dynamic
+-
+-  ifeq ($(AMD),yes)
+-     FFLAGS1     :=  $(INCDIRS) -g -traceback -O2 -assume byterecl -132 -mcmodel=medium -shared-intel -assume buffered_io
+-  else
+-     FFLAGS1     :=  $(INCDIRS) -O3 -g -traceback -xSSE4.2 -assume byterecl -132 -mcmodel=medium -shared-intel -assume buffered_io
+-#      FFLAGS1     :=  $(INCDIRS) -O2 -g -traceback -xSSE4.2 -assume byterecl -132 -mcmodel=medium -shared-intel -assume buffered_io
+-#      FFLAGS1     :=  $(INCDIRS) -O0 -g -traceback -check bounds -xSSE4.2 -assume byterecl -132 -mcmodel=medium -shared-intel -assume buffered_io
+-  endif
++  PFC           :=  mpif90
++  FFLAGS1       :=  $(INCDIRS) -w -O2 -assume byterecl -132 -i-dynamic
+   ifeq ($(DEBUG),full)
+-     FFLAGS1    :=  $(INCDIRS) -g -O0 -traceback -debug -check all -FI -assume byterecl -132 -DEBUG -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
++     FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -debug -check all -i-dynamic -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
+   endif
+   FFLAGS2       :=  $(FFLAGS1)
+   FFLAGS3       :=  $(FFLAGS1)
+   DA            :=  -DREAL8 -DLINUX -DCSCA
+-  DP            :=  -DREAL8 -DLINUX -DCSCA -DCMPI -DHAVE_MPI_MOD #-DNOFSBPG #-DNOIVB -DPOWELL
++  DP            :=  -DREAL8 -DLINUX -DCSCA -DCMPI -DPOWELL
+   DPRE          :=  -DREAL8 -DLINUX -DADCSWAN
+   ifeq ($(SWAN),enable)
+-     DPRE       := $(DPRE) -DADCSWAN
++     DPRE          := $(DPRE) -DADCSWAN
+   endif
+   IMODS         :=  -I
+   CC            := icc
+   CCBE          := $(CC)
+-  CFLAGS        := $(INCDIRS) -O3 -m64 -mcmodel=medium -DLINUX
+-  FLIBS         := 
+-  ifeq ($(DATETIME),enable)
+-     DATETIMEHOME  := /asclepius/cblakely/libs/OC-GTSM_utility/libs/datetime-fortran/build/
+-     FLIBS         := -ldatetime -L$(DATETIMEHOME)lib/
+-  endif
+-  ifeq ($(GRIB2),enable)
+-     WGRIB2HOME    := /asclepius/cblakely/libs/grib2/lib/
+-     FLIBS         := $(FLIBS) -lwgrib2_api -lwgrib2 -ljasper -L$(WGRIB2HOME)
+-  endif
++  CFLAGS        := $(INCDIRS) -O2 -m64 -mcmodel=medium -DLINUX
++  FLIBS          :=
+   ifeq ($(DEBUG),full)
+-     CFLAGS     := $(INCDIRS) -g -O0 -m64 -mcmodel=medium -DLINUX
++     CFLAGS        := $(INCDIRS) -g -O0 -march=k8 -m64 -mcmodel=medium -DLINUX
+   endif
+   ifeq ($(NETCDF),enable)
+-     #HDF5HOME=/afs/crc.nd.edu/x86_64_linux/hdf/hdf5-1.8.6-linux-x86_64-static/lib
+-     HDF5HOME=/opt/crc/n/netcdf/4.7.0/intel/18.0      
+-     FLIBS      := $(FLIBS) -lnetcdff -L$(HDF5HOME) 
++     HDF5HOME=/afs/crc.nd.edu/x86_64_linux/hdf/hdf5-1.8.6-linux-x86_64-static/lib
++     FLIBS      := $(FLIBS) -lnetcdff -L$(HDF5HOME)
+   endif
+-# ------------
+-  ifeq ($(NETCDF),enable)
+-    ifeq ($(WDALTVAL),enable)
+-       DP  := $(DP) -DWDVAL_NETCDF 
+-    endif
+-  endif
+-# -----------
+-
+   CLIBS         :=
+   MSGLIBS       :=
+   $(warning (INFO) Corresponding machine found in cmplrflags.mk.)
+@@ -418,23 +524,24 @@ ifeq ($(compiler),intel-ND)
+   else
+      MULTIPLE := TRUE
+   endif
+-  NETCDFHOME=/afs/crc.nd.edu/x86_64_linux/n/netcdf/4.7.0/intel/18.0/
++  NETCDFHOME=/afs/crc.nd.edu/x86_64_linux/netcdf/rhel6/4.1.3/intel-12.0/
++  #NETCDFHOME=/afs/crc.nd.edu/x86_64_linux/scilib/netcdf/4.1.2/intel-12.0/inst
+ endif
+-
++#
+ # SGI ICE X (e.g. topaz@ERDC) using Intel compilers, added by TCM
+ # jgf: Added flags for Thunder@AFRL.
+ ifeq ($(compiler),intel-sgi)
+   PPFC          :=  ifort
+   FC            :=  ifort
+-  PFC           ?=  mpif90
++  PFC           :=  mpif90
+   CC            :=  icc -O2 -no-ipo
+   CCBE          :=  icc -O2 -no-ipo
+-  FFLAGS1       :=  $(INCDIRS) -fixed -extend-source 132 -O2 -finline-limit=1000 -real-size 64 -no-ipo -assume buffered_io
++  FFLAGS1       :=  $(INCDIRS) -fixed -extend-source 132 -O2 -finline-limit=1000 -real-size 64 -no-ipo
+ #  FFLAGS1      :=  $(INCDIRS) -Mextend -g -O0 -traceback
+   FFLAGS2       :=  $(FFLAGS1)
+   FFLAGS3       :=  $(FFLAGS1) -assume buffered_stdout
+   DA            :=  -DREAL8 -DLINUX -DCSCA
+-  DP            :=  -DREAL8 -DLINUX -DCMPI -DCSCA
++  DP            :=  -DREAL8 -DLINUX -DCMPI -DHAVE_MPI_MOD -DCSCA
+   DPRE          :=  -DREAL8 -DLINUX
+   CFLAGS        :=  $(INCDIRS) -DLINUX
+   IMODS         :=  -module
+@@ -474,8 +581,8 @@ ifeq ($(compiler),cray_xt3)
+   FFLAGS2	:=  $(FFLAGS1)
+   FFLAGS3	:=  $(FFLAGS1) -r8 -Mr8 -Mr8intrinsics
+   DA  	        :=  -DREAL8 -DLINUX -DCSCA
+-  DP  	        :=  -DREAL8 -DLINUX -DCMPI -DCSCA -DDEBUG_WARN_ELEV
+-#  DP  	        :=  -DREAL8 -DLINUX -DCMPI -DCSCA
++  DP  	        :=  -DREAL8 -DLINUX -DCMPI -DHAVE_MPI_MOD -DCSCA -DDEBUG_WARN_ELEV
++#  DP  	        :=  -DREAL8 -DLINUX -DCMPI -DHAVE_MPI_MOD -DCSCA
+   DPRE	        :=  -DREAL8 -DLINUX
+   CFLAGS	:=  -c89 $(INCDIRS) -DLINUX
+   IMODS		:=  -module
+@@ -512,7 +619,7 @@ ifeq ($(compiler),cray_xt4)
+   FFLAGS2	:=  $(FFLAGS1)
+   FFLAGS3	:=  $(FFLAGS1) -r8 -Mr8 -Mr8intrinsics
+   DA  	        :=  -DREAL8 -DLINUX -DCSCA
+-  DP  	        :=  -DREAL8 -DLINUX -DCMPI -DCSCA
++  DP  	        :=  -DREAL8 -DLINUX -DCMPI -DHAVE_MPI_MOD -DCSCA
+   DPRE	        :=  -DREAL8 -DLINUX
+   ifeq ($(SWAN),enable)
+      DPRE	        :=  -DREAL8 -DLINUX -DADCSWAN
+@@ -556,7 +663,7 @@ ifeq ($(compiler),cray_xt5)
+   FFLAGS2	:=  $(FFLAGS1)
+   FFLAGS3	:=  $(FFLAGS1) -r8 -Mr8 -Mr8intrinsics
+   DA  	        :=  -DREAL8 -DLINUX -DCSCA
+-  DP  	        :=  -DREAL8 -DLINUX -DCMPI -DCSCA
++  DP  	        :=  -DREAL8 -DLINUX -DCMPI -DHAVE_MPI_MOD -DCSCA
+   DPRE	        :=  -DREAL8 -DLINUX
+   CFLAGS	:=  -c89 $(INCDIRS) -DLINUX
+   IMODS		:=  -module
+@@ -585,12 +692,12 @@ ifeq ($(compiler),xtintel)
+   PFC           :=  ftn
+   CC            :=  cc -O2 -no-ipo
+   CCBE          :=  cc -O2 -no-ipo
+-  FFLAGS1       :=  $(INCDIRS) -fixed -extend-source 132 -O2 -default64 -finline-limit=1000 -real-size 64 -no-ipo -assume buffered_io
++  FFLAGS1       :=  $(INCDIRS) -fixed -extend-source 132 -O2 -default64 -finline-limit=1000 -real-size 64 -no-ipo
+ #  FFLAGS1      :=  $(INCDIRS) -Mextend -g -O0 -traceback
+   FFLAGS2       :=  $(FFLAGS1)
+   FFLAGS3       :=  $(FFLAGS1) -assume buffered_stdout
+   DA            :=  -DREAL8 -DLINUX -DCSCA
+-  DP            :=  -DREAL8 -DLINUX -DCMPI -DCSCA
++  DP            :=  -DREAL8 -DLINUX -DCMPI -DHAVE_MPI_MOD -DCSCA
+   DPRE          :=  -DREAL8 -DLINUX
+   CFLAGS        :=  $(INCDIRS) -DLINUX
+   IMODS         :=  -module
+@@ -652,7 +759,7 @@ ifeq ($(compiler),utils)
+   FFLAGS2       :=  $(FFLAGS1)
+   FFLAGS3       :=  $(FFLAGS1) -r8 -Mr8 -Mr8intrinsics
+   DA            :=  -DREAL8 -DLINUX -DCSCA
+-  DP            :=  -DREAL8 -DLINUX -DCMPI -DCSCA
++  DP            :=  -DREAL8 -DLINUX -DCMPI -DHAVE_MPI_MOD -DCSCA
+   DPRE          :=  -DREAL8 -DLINUX
+   ifeq ($(SWAN),enable)
+      DPRE               :=  -DREAL8 -DLINUX -DADCSWAN
+@@ -717,15 +824,15 @@ ifeq ($(compiler),diamond)
+   PPFC          :=  ifort
+   FC            :=  ifort
+   PFC           :=  ifort
+-#  FFLAGS1       :=  $(INCDIRS) -O3 -xT -132
+-  FFLAGS1       := -O3 -132 -xSSSE3
++#  FFLAGS1       :=  $(INCDIRS) -O2 -xT -132
++  FFLAGS1       := -O2 -132 -xSSSE3
+   ifeq ($(DEBUG),full)
+      FFLAGS1	:=  $(INCDIRS) -g -O0 -debug -fpe0 -132 -traceback -check all -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK
+   endif
+   FFLAGS2       :=  $(FFLAGS1)
+   FFLAGS3       :=  $(FFLAGS1)
+   DA            :=  -DREAL8 -DLINUX -DCSCA
+-  DP            :=  -DREAL8 -DLINUX -DCSCA -DCMPI 
++  DP            :=  -DREAL8 -DLINUX -DCSCA -DCMPI -DHAVE_MPI_MOD
+   DPRE          :=  -DREAL8 -DLINUX
+   ifeq ($(SWAN),enable)
+      DPRE          :=  -DREAL8 -DLINUX -DADCSWAN
+@@ -733,8 +840,8 @@ ifeq ($(compiler),diamond)
+   IMODS         :=  -I
+   CC            := icc
+   CCBE          := $(CC)
+-#  CFLAGS        := $(INCDIRS) -O3 -xT
+-  CFLAGS        := $(INCDIRS) -O3 -xSSSE3
++#  CFLAGS        := $(INCDIRS) -O2 -xT
++  CFLAGS        := $(INCDIRS) -O2 -xSSSE3
+   ifeq ($(DEBUG),full)
+      CFLAGS        := $(INCDIRS) -g -O0
+   endif
+@@ -775,7 +882,7 @@ ifeq ($(compiler),garnet)
+   FFLAGS2	:=  $(FFLAGS1)
+   FFLAGS3	:=  $(FFLAGS1) #-r8 -Mr8 -Mr8intrinsics
+   DA  	        :=  -DREAL8 -DLINUX -DCSCA
+-  DP  	        :=  -DREAL8 -DLINUX -DCMPI -DCSCA
++  DP  	        :=  -DREAL8 -DLINUX -DCMPI -DHAVE_MPI_MOD -DCSCA
+   DPRE	        :=  -DREAL8 -DLINUX
+   ifeq ($(SWAN),enable)
+      DPRE	        :=  -DREAL8 -DLINUX -DADCSWAN
+@@ -810,7 +917,7 @@ ifeq ($(compiler),kraken)
+   PPFC          :=  ftn
+   FC            :=  ftn
+   PFC           :=  ftn
+-  FFLAGS1       :=  $(INCDIRS) -O3 -static  -132
++  FFLAGS1       :=  $(INCDIRS) -O2 -static  -132
+   FFLAGS2       :=  $(FFLAGS1)
+   FFLAGS3       :=  $(FFLAGS1)
+   DA            :=  -DREAL8 -DLINUX -DCSCA -DPOWELL
+@@ -834,24 +941,24 @@ endif
+ #
+ # Compiler Flags for CircleCI Build Server
+ ifeq ($(compiler),circleci)
+-  PPFC		:=  ifort
+-  FC		:=  ifort
++  PPFC		:=  gfortran
++  FC		:=  gfortran
+   PFC		:=  mpif90
+-  FFLAGS1	:=  $(INCDIRS) -O0 -132
++  FFLAGS1	:=  $(INCDIRS) -O0 -g -mcmodel=medium -ffixed-line-length-none -m64
+   FFLAGS2	:=  $(FFLAGS1)
+   FFLAGS3	:=  $(FFLAGS1)
+   DA		:=  -DREAL8 -DLINUX -DCSCA
+-  DP		:=  -DREAL8 -DLINUX -DCSCA -DCMPI 
++  DP		:=  -DREAL8 -DLINUX -DCSCA -DCMPI -DHAVE_MPI_MOD
+   DPRE		:=  -DREAL8 -DLINUX -DADCSWAN
+   IMODS 	:=  -I
+-  CC		:= icx
++  CC		:= gcc
+   CCBE		:= $(CC)
+-  CFLAGS	:= $(INCDIRS) -O0 -mcmodel=medium -DLINUX -m64
++  CFLAGS	:= $(INCDIRS) -O0 -g -mcmodel=medium -DLINUX -m64
+   CLIBS	:=
+   LIBS		:=
+   MSGLIBS	:=
+   ifeq ($(NETCDF),enable)
+-     FLIBS          := $(FLIBS) -L${NETCDF_C_HOME}/lib -lnetcdff
++     FLIBS          := $(FLIBS) -lnetcdff
+   endif
+   $(warning (INFO) Corresponding compilers and flags found in cmplrflags.mk.)
+   ifneq ($(FOUND),TRUE)
+@@ -860,8 +967,7 @@ ifeq ($(compiler),circleci)
+      MULTIPLE := TRUE
+   endif
+ endif
+-#
+-endif
++
+ #$(MACHINE)
+ ########################################################################
+ # Compiler flags for Linux operating system on 32bit x86 CPU
+@@ -908,7 +1014,7 @@ endif
+ ifeq ($(compiler),intel)
+   PPFC	        :=  ifort -w
+   FC	        :=  ifort -w
+-  PFC	        ?=  mpif90
++  PFC	        :=  mpif90
+   OPTLVL        := -O2
+   ifeq ($(ADC_DEBUG),yes)
+     OPTLVL        := -g
+@@ -917,7 +1023,7 @@ ifeq ($(compiler),intel)
+   FFLAGS2	:=  $(FFLAGS1)
+   FFLAGS3	:=  $(FFLAGS1)
+   DA  	        :=  -DREAL8 -DLINUX -DCSCA
+-  DP  	        :=  -DREAL8 -DLINUX -DCSCA -DCMPI 
++  DP  	        :=  -DREAL8 -DLINUX -DCSCA -DCMPI -DHAVE_MPI_MOD
+   DPRE	        :=  -DREAL8 -DLINUX
+   IMODS 	:=  -I
+   CC            := icc
+@@ -989,69 +1095,6 @@ ifeq ($(compiler),gnu)
+   endif
+ endif
+ #
+-# gfortran
+-ifeq ($(compiler),gfortran)
+-  ifeq ($(MACHINENAME),jason-desktop)
+-     XDMFPATH    := /home/jason/projects/XDMF/Code/latestCode
+-     XDMFLIBPATH := /home/jason/projects/XDMF/Code/testLatest
+-  endif
+-  PPFC		:=  gfortran
+-  FC		:=  gfortran
+-  PFC		:=  mpif90
+-  FFLAGS1	:=  $(INCDIRS) -O2 -ffixed-line-length-none
+-  ifeq ($(PROFILE),enable)
+-    FFLAGS1	:=  $(INCDIRS) -pg -O0 -fprofile-arcs -ftest-coverage -ffixed-line-length-none
+-  endif
+-  ifeq ($(DEBUG),full)
+-    FFLAGS1	:=  $(INCDIRS) -g -O0 -ffixed-line-length-none -fbacktrace -fbounds-check -ffpe-trap=zero,invalid,overflow,denormal -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK -DDEBUG_HOLLAND -DDEBUG_WARN_ELEV
+-  endif
+-  ifeq ($(DEBUG),compiler-warnings)
+-    FFLAGS1	:=  $(INCDIRS) -g -O0 -Wall -Wextra -ffixed-line-length-none -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK
+-  endif
+-  ifeq ($(DEBUG),full-not-warnelev)
+-    FFLAGS1	:=  $(INCDIRS) -g -O0 -ffixed-line-length-none -fbacktrace -fbounds-check -ffpe-trap=zero,invalid,overflow,denormal -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK -DDEBUG_HOLLAND
+-  endif
+-  ifeq ($(DEBUG),full-not-fpe)
+-    FFLAGS1	:=  $(INCDIRS) -g -O0 -ffixed-line-length-none -fbacktrace -fbounds-check -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK -DDEBUG_HOLLAND
+-  endif
+-  ifeq ($(DEBUG),trace)
+-    FFLAGS1	:=  $(INCDIRS) -g -O0 -ffixed-line-length-none -fbacktrace -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK
+-  endif
+-  ifneq ($(MACHINENAME),jason-desktop)
+-     FFLAGS1 := $(FFLAGS1) -fno-underscoring
+-  endif
+-  FFLAGS2	:=  $(FFLAGS1)
+-  FFLAGS3	:=  $(FFLAGS1)
+-  DA		:=  -DREAL8 -DLINUX -DCSCA
+-  DP		:=  -DREAL8 -DLINUX -DCSCA -DCMPI
+-  DPRE		:=  -DREAL8 -DLINUX
+-  ifeq ($(SWAN),enable)
+-     DPRE               :=  -DREAL8 -DLINUX -DADCSWAN
+-  endif
+-  FLIBS         :=
+-  ifeq ($(NETCDF),enable)
+-     ifeq ($(MACHINENAME),jason-desktop)
+-        NETCDFHOME := /usr
+-     endif
+-     FLIBS      := $(FLIBS) -lnetcdff
+-  endif
+-  IMODS 	:=  -I
+-  CC		:= gcc
+-  CCBE		:= $(CC)
+-  CFLAGS	:= $(INCDIRS) -O2 -DLINUX
+-  ifeq ($(DEBUG),full)
+-     CFLAGS     := $(INCDIRS) -g -O0 -DLINUX
+-  endif
+-  CLIBS	:=
+-  MSGLIBS	:=
+-  $(warning (INFO) Corresponding machine found in cmplrflags.mk.)
+-  ifneq ($(FOUND),TRUE)
+-     FOUND := TRUE
+-  else
+-     MULTIPLE := TRUE
+-  endif
+-endif
+-
+ endif
+ 
+ ########################################################################
+@@ -1096,7 +1139,7 @@ ifeq ($(arch),altix)
+   PPFC            := ifort
+   FC              := ifort
+   PFC             := ifort
+-  FFLAGS1	  := $(INCDIRS) -O3 -tpp2
++  FFLAGS1	  := $(INCDIRS) -O2 -tpp2
+   FFLAGS2	  := $(FFLAGS1)
+   FFLAGS3	  := $(FFLAGS1)
+   DA	          :=  -DREAL8 -DCSCA
+@@ -1169,7 +1212,7 @@ ifeq ($(IBM),p5)
+   FFLAGS0       := $(INCDIRS) -w -qfixed=132 -qarch=auto -qcache=auto
+   FFLAGS1       := $(FFLAGS0) -O2
+   FFLAGS2       := $(FFLAGS0) -qhot -qstrict
+-  FFLAGS3       := $(FFLAGS0) -O3 -qinitauto
++  FFLAGS3       := $(FFLAGS0) -O2 -qinitauto
+   DA            := -WF,"-DREAL8,-DIBM,-DCSCA"
+   DP            := -tF -WF,"-DREAL8,-DIBM,-DCSCA,-DCMPI"
+   DPRE          := -tF -WF,"-DREAL8,-DIBM"
+@@ -1489,9 +1532,9 @@ ifneq (,$(findstring powerpc-darwin,$(MACHINE)-$(OS)))
+   PPFC	        := f90
+   FC	        := f90
+   PFC	        := mpif77
+-  FFLAGS1	:=  $(INCDIRS) -w -O3 -m64 -cpu:g5 -f fixed -W132 -I. -DLINUX
+-  FFLAGS2	:=  $(INCDIRS) -w -O3 -m64 -cpu:g5 -N11 -f fixed -W132 -I.
+-  FFLAGS3	:=  $(INCDIRS) -w -O3 -m64 -cpu:g5 -N11 -f fixed -W132 -I.
++  FFLAGS1	:=  $(INCDIRS) -w -O2 -m64 -cpu:g5 -f fixed -W132 -I . -DLINUX
++  FFLAGS2	:=  $(INCDIRS) -w -O2 -m64 -cpu:g5 -N11 -f fixed -W132 -I .
++  FFLAGS3	:=  $(INCDIRS) -w -O2 -m64 -cpu:g5 -N11 -f fixed -W132 -I .
+   DA  	   	:=  -DREAL8 -DCSCA -DLINUX
+   DP  	   	:=  -DREAL8 -DCSCA -DCMPI -DLINUX
+   DPRE	   	:=  -DREAL8 -DLINUX
+@@ -1519,17 +1562,17 @@ ifneq (,$(findstring i386-darwin,$(MACHINE)-$(OS)))
+   PPFC	        := ifort
+   FC	        := ifort
+   PFC	        := mpif77
+-  FFLAGS1       :=  $(INCDIRS) -nowarn -O3    -fixed -132 -check all -traceback -DLINUX -DNETCDF_DEBUG -I.
+-# FFLAGS1	:=  $(INCDIRS) -nowarn -O3    -fixed -132 -DIBM -I.
+-  FFLAGS2	:=  $(INCDIRS) -nowarn -O3    -fixed -132 -I.
+-  FFLAGS3	:=  $(INCDIRS) -nowarn -O3    -fixed -132 -I.
++  FFLAGS1       :=  $(INCDIRS) -nowarn -O2    -fixed -132 -check all -traceback -DLINUX -DNETCDF_DEBUG -I .
++# FFLAGS1	:=  $(INCDIRS) -nowarn -O2    -fixed -132 -DIBM -I .
++  FFLAGS2	:=  $(INCDIRS) -nowarn -O2    -fixed -132 -I .
++  FFLAGS3	:=  $(INCDIRS) -nowarn -O2    -fixed -132 -I .
+   DA  	   	:=  -DREAL8 -DCSCA -DLINUX
+   DP  	   	:=  -DREAL8 -DCSCA -DLINUX -DCMPI -DNETCDF_DEBUG
+   DPRE	   	:=  -DREAL8 -DLINUX
+   IMODS  	:=  -I
+   CC            :=  gcc
+   CCBE          :=  $(CC)
+-  CFLAGS        :=  $(INCDIRS) -O3 -DLINUX
++  CFLAGS        :=  $(INCDIRS) -O2 -DLINUX
+   LDFLAGS	:=
+   FLIBS	        :=
+   MSGLIBS	:=

--- a/patches/ADCIRC/v56.0.4/02-macros-inc-gfortran.patch
+++ b/patches/ADCIRC/v56.0.4/02-macros-inc-gfortran.patch
@@ -1,0 +1,13 @@
+diff --git a/thirdparty/swan/macros.inc.gfortran b/thirdparty/swan/macros.inc.gfortran
+index ef13f34..2c6fbdf 100644
+--- a/thirdparty/swan/macros.inc.gfortran
++++ b/thirdparty/swan/macros.inc.gfortran
+@@ -5,7 +5,7 @@ F90_SER = gfortran
+ F90_OMP = gfortran
+ F90_MPI = mpif90
+ FLAGS_OPT = -O
+-FLAGS_MSC = -w -fno-second-underscore -ffree-line-length-none -fallow-argument-mismatch
++FLAGS_MSC = -w -fno-second-underscore -ffree-line-length-none
+ FLAGS90_MSC = $(FLAGS_MSC) -ffree-line-length-none
+ FLAGS_SER =
+ FLAGS_OMP = -fopenmp

--- a/patches/ADCIRC/v56.0.4/03-DEBUG_WARN_ELEV.patch
+++ b/patches/ADCIRC/v56.0.4/03-DEBUG_WARN_ELEV.patch
@@ -1,0 +1,90 @@
+diff --git a/src/read_input.F b/src/read_input.F
+index 2d4009b..f1fb267 100644
+--- a/src/read_input.F
++++ b/src/read_input.F
+@@ -682,6 +682,31 @@ C     WJP add namelist
+       call logMessage(ECHO,trim(scratchMessage))
+       rewind(15)
+ 
++      if(iWarnElevDump.ne.0) WarnElevDump = .True.
++      write(scratchMessage,'(A,e16.8)') 'A warning will be issued '//
++     &                     'if elevation exceeds WarnElev = ',WarnElev
++      call logMessage(INFO,scratchMessage)
++      if(WarnElevDump)then
++          write(scratchMessage,'(A,e16.8,A)') 
++     &     'A global elevation file (fort.69)'//
++     &     ' will be written if WarnElev (',WarnElev,') is exceeded'
++          call logMessage(INFO,scratchMessage)
++          write(scratchMessage,'(A,I0,A)') 
++     &     'Execution will be terminated '//
++     &     'if ',WarnElevDumpLimit,' global elevation snaps have been '//
++     &     'written as warning.'
++          call logMessage(INFO,scratchMessage)
++      else
++          write(scratchMessage,'(A,e16.8,A)') 
++     &     'A global elevation file (fort.69)'//
++     &     ' will NOT be written if WarnElev (',WarnElev,') is exceeded'
++          call logMessage(INFO,scratchMessage)
++      endif    
++      write(scratchMessage,'(A,e16.8)') 
++     &     'Execution will be terminated if elevation exceeds ',
++     &     ErrorElev 
++      call logMessage(INFO,scratchMessage)
++
+ !     WJP add namelist for Ali's dispersion
+ !     Defaults are already in global 
+       namelistSpecifier = 'AliDispersionControl'
+@@ -811,20 +836,6 @@ C
+  1952    FORMAT(/,5X,'NFOVER = ',I3,
+      &        /,9X,'NON-FATAL INPUT ERRORS WILL STOP EXECUTION ',/)
+       ENDIF
+-#ifdef DEBUG_WARN_ELEV
+-      IF (iWarnElevDump .ne. 0) WarnElevDump = .True.
+-      WRITE(16,1953) WarnElev,WarnElevDump,WarnElevDumpLimit,ErrorElev
+- 1953 FORMAT(//,5X,
+-     &     'A warning will be issued if elevation exceeds WarnElev = ',
+-     &     e16.8,
+-     &     /,5X,'A global elevation file (fort.69) will be written if '
+-     &     /,5X,'WarnElev is exceeded and WarnElevDump is true: ',L2,
+-     &     /,5X,'Execution will be terminated if ',
+-     &     '(WarnElevDumpLimit = 'I3,') ',
+-     &     /,5X,'global elevation files have been written as warning.'
+-     &     /,5X,'Execution will be terminated if elevation exceeds'
+-     &     ' ErrorElev =',e16.8)
+-#endif
+ C...
+ C...  READ AND PROCESS NABOUT - ABBREVIATED UNIT 16 OUTPUT OPTION
+ C...
+diff --git a/src/timestep.F b/src/timestep.F
+index fb6c9e6..54eea92 100644
+--- a/src/timestep.F
++++ b/src/timestep.F
+@@ -1333,12 +1333,13 @@ C     output the global node number to debug the local PE fort.14s
+      &           3X,'** WARNING: Elevation.gt.WarnElev **')
+             IF (WarnElevDump) WarnElevExceeded=1
+          ENDIF
+-#ifdef DEBUG_WARN_ELEV
+-         call WarnElevSum(WarnElevExceeded)
+-         IF (WarnElevExceeded.ne.0) THEN
+-            CALL WriteWarnElev(TimeLoc, IT)
++
++         IF(WarnElevDump)THEN
++             call WarnElevSum(WarnElevExceeded)
++             IF (WarnElevExceeded.ne.0) THEN
++                CALL WriteWarnElev(TimeLoc, IT)
++             ENDIF
+          ENDIF
+-#endif
+          ErrorElevExceeded = 0                ! Clint's Zombie Slyaer
+          IF(ELMAX.GT.ErrorElev) THEN
+ 
+@@ -1409,9 +1410,7 @@ C     output the global node number to debug the local PE fort.14s
+      &           /,2X,'ELMAX = ', 1pE12.4E3,' AT NODE ',I9,
+      &           2X,'SPEEDMAX = ',1pE12.4E3,' AT NODE ',I9,
+      &           2X,'** WARNING: Elevation.gt.WarnElev **')
+-#ifdef DEBUG_WARN_ELEV
+             IF (WarnElevDump) CALL WriteWarnElev(TimeLoc, IT)
+-#endif
+          ENDIF
+          IF(ELMAX.GT.ErrorElev) THEN
+             write(6,*) 'elmax, errorelev',elmax, errorelev !jgf

--- a/patches/ADCIRC/v56.0.4/04-thirdparty-swan-platform-pl.patch
+++ b/patches/ADCIRC/v56.0.4/04-thirdparty-swan-platform-pl.patch
@@ -1,0 +1,73 @@
+diff --git a/thirdparty/swan/platform.pl b/thirdparty/swan/platform.pl
+index 2cb2390..12d619b 100644
+--- a/thirdparty/swan/platform.pl
++++ b/thirdparty/swan/platform.pl
+@@ -299,6 +299,59 @@ elsif ($os =~ /Linux/i) {
+     print OUTFILE "  swch = -unix -impi\n";
+     print OUTFILE "endif\n";
+   }
++  elsif ( $compiler eq "ifx" )
++  {
++    print OUTFILE <<EOF;
++################################################################################
++# Intel/x86-64_Intel:    Intel Core/Xeon with Linux using Intel OneAPI compiler.
++################################################################################
++F90_SER = ifx
++F90_OMP = ifx
++# for older compiler versions, use mpif90
++F90_MPI = mpiifx
++FLAGS_OPT = -O2
++FLAGS_MSC = -W0 -assume byterecl -traceback -diag-disable 8290 -diag-disable 8291 -diag-disable 8293
++FLAGS90_MSC = \$(FLAGS_MSC)
++FLAGS_DYN = -fPIC
++FLAGS_SER =
++FLAGS_OMP = -qopenmp
++FLAGS_MPI =
++NETCDFROOT =
++ifneq (\$(NETCDFROOT),)
++  INCS_SER = -I\$(NETCDFROOT)/include
++  INCS_OMP = -I\$(NETCDFROOT)/include
++  INCS_MPI = -I\$(NETCDFROOT)/include
++  LIBS_SER = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff
++  LIBS_OMP = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff
++  LIBS_MPI = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff
++  NCF_OBJS = nctablemd.o agioncmd.o swn_outnc.o
++else
++  INCS_SER =
++  INCS_OMP =
++  INCS_MPI =
++  LIBS_SER =
++  LIBS_OMP =
++  LIBS_MPI =
++  NCF_OBJS =
++endif
++O_DIR = ../work/odir4/
++BOU_OBJ = \$(O_DIR)boundaries.o
++ifneq (\"\$(wildcard \$(BOU_OBJ))\",\"\")
++  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)boundaries.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o
++else
++  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o
++endif
++OUT = -o 
++EXTO = o
++MAKE = make
++RM = rm -f
++ifneq (\$(NETCDFROOT),)
++  swch = -unix -impi -netcdf
++else
++  swch = -unix -impi
++endif
++EOF
++  }
+   elsif ( $compiler eq "ifc" )
+   {
+     print OUTFILE "##############################################################################\n";
+@@ -883,7 +936,7 @@ sub getcmpl {
+    my $compiler = $ENV{'FC'};
+ 
+    unless ( $compiler ) {
+-      foreach ('ifort','gfortran','f90','ifc','efc','pgf90','xlf90', 'lf95','g95','ifort.exe') {
++      foreach ('ifx','ifort','gfortran','f90','ifc','efc','pgf90','xlf90', 'lf95','g95','ifort.exe') {
+          $compiler = $_;
+          my $path  = `which $compiler`;
+          last if $path;

--- a/patches/ADCIRC/v56.0.4/about.txt
+++ b/patches/ADCIRC/v56.0.4/about.txt
@@ -1,0 +1,1 @@
+(latest) upstream release version v56.0.4

--- a/patches/ADCIRC/v56.0.4/info.sh
+++ b/patches/ADCIRC/v56.0.4/info.sh
@@ -1,0 +1,5 @@
+export ADCIRC_SRC_TYPE=git
+export ADCIRC_GIT_URL=https://github.com/adcirc
+export ADCIRC_GIT_REPO=adcirc
+export ADCIRC_GIT_BRANCH=v56.0.4 # release tag
+export SWANDIR=thirdparty/swan


### PR DESCRIPTION
Issdue 1482:

Resolves #1482.


Testing (via `build adcirc`, `load adcirc`, and `verify adcirc`)

- [x] QBC
- [x] QBD
- [x] smic
- [x] supermikeiii
- [x] Stampede3
- [x] Lonestar6
- [ ] Debian (gfortran 9)
- [x] Debian (oneAPI)