### PR TITLE
Add pre-calibrated river flux templates (6–10kcms) for CPRA24 and LAERDC meshes

### DIFF
--- a/input/meshes/CPRA24/CPRA24_10kcms_river_flux.txt
+++ b/input/meshes/CPRA24/CPRA24_10kcms_river_flux.txt
@@ -1,0 +1,45 @@
+ STEADY               ! 10kcms CONSTITUENT. 1  ALPHA DESCRIPTOR
+ 0.00000E-00  1.0 0.0   ! CONSTITUENT. 1 FREQ.   NODAL FACTOR   EQUIL. ARG.
+ STEADY       ! ALPHA NUMERIC DESCRIPTION OF ELEVATION BOUNDARY FORCING
+4.2933560 .000000    !...River 1 Node 1 (MS River Total River Flow: 10000.0000 cms, Avg Lat/Long: -91.198941,30.425086)
+9.2668680 .000000    !...River 1 Node 2
+10.486278 .000000    !...River 1 Node 3
+11.391818 .000000    !...River 1 Node 4
+12.030548 .000000    !...River 1 Node 5
+12.285756 .000000    !...River 1 Node 6
+11.843390 .000000    !...River 1 Node 7
+10.382702 .000000    !...River 1 Node 8
+8.0905660 .000000    !...River 1 Node 9
+5.6512460 .000000    !...River 1 Node 10
+3.6138780 .000000    !...River 1 Node 11
+2.5023000 .000000    !...River 1 Node 12
+1.1226740 .000000    !...River 1 Node 13
+0.0000000 .000000    !...River 2 Node 1 (Total River Flow: .0000 cms, Avg Lat/Long: -91.619574,30.776798)
+0.0000000 .000000    !...River 2 Node 2
+0.0000000 .000000    !...River 2 Node 3
+0.0000000 .000000    !...River 2 Node 4
+0.0000000 .000000    !...River 2 Node 5
+0.0000000 .000000    !...River 2 Node 6
+0.0000000 .000000    !...River 2 Node 7
+1.2643520 .000000    !...River 3 Node 1 (Atch - Total River Flow:   cms, Avg Lat/Long: -91.801121,30.979759)
+2.6293000 .000000    !...River 3 Node 2
+2.8262840 .000000    !...River 3 Node 3
+3.0091460 .000000    !...River 3 Node 4
+3.2031540 .000000    !...River 3 Node 5
+3.3683380 .000000    !...River 3 Node 6
+3.4259860 .000000    !...River 3 Node 7
+3.4287100 .000000    !...River 3 Node 8
+3.4483840 .000000    !...River 3 Node 9
+3.4894220 .000000    !...River 3 Node 10
+3.5240620 .000000    !...River 3 Node 11
+3.5353260 .000000    !...River 3 Node 12
+3.5360520 .000000    !...River 3 Node 13
+3.5360660 .000000    !...River 3 Node 14
+3.5330100 .000000    !...River 3 Node 15
+3.5116020 .000000    !...River 3 Node 16
+3.4687820 .000000    !...River 3 Node 17
+3.4351520 .000000    !...River 3 Node 18
+3.3902800 .000000    !...River 3 Node 19
+3.2499420 .000000    !...River 3 Node 20
+3.0178740 .000000    !...River 3 Node 21
+1.4452180 .000000    !...River 3 Node 22

--- a/input/meshes/CPRA24/CPRA24_7kcms_river_flux.txt
+++ b/input/meshes/CPRA24/CPRA24_7kcms_river_flux.txt
@@ -1,0 +1,45 @@
+ STEADY               ! 7kcms CONSTITUENT. 1  ALPHA DESCRIPTOR
+ 0.00000E-00  1.0 0.0   ! CONSTITUENT. 1 FREQ.   NODAL FACTOR   EQUIL. ARG.
+ STEADY       ! ALPHA NUMERIC DESCRIPTION OF ELEVATION BOUNDARY FORCING
+3.0053492 .000000    !...River 1 Node 1 (MS River Total River Flow: 7000.0000 cms, Avg Lat/Long: -91.198941,30.425086)
+6.4868076 .000000    !...River 1 Node 2
+7.3403946 .000000    !...River 1 Node 3
+7.9742726 .000000    !...River 1 Node 4
+8.4213836 .000000    !...River 1 Node 5
+8.6000292 .000000    !...River 1 Node 6
+8.2903730 .000000    !...River 1 Node 7
+7.2678914 .000000    !...River 1 Node 8
+5.6633962 .000000    !...River 1 Node 9
+3.9558722 .000000    !...River 1 Node 10
+2.5297146 .000000    !...River 1 Node 11
+1.7516100 .000000    !...River 1 Node 12
+0.7858718 .000000    !...River 1 Node 13
+0.0000000 .000000    !...River 2 Node 1 (Total River Flow: .0000 cms, Avg Lat/Long: -91.619574,30.776798)
+0.0000000 .000000    !...River 2 Node 2
+0.0000000 .000000    !...River 2 Node 3
+0.0000000 .000000    !...River 2 Node 4
+0.0000000 .000000    !...River 2 Node 5
+0.0000000 .000000    !...River 2 Node 6
+0.0000000 .000000    !...River 2 Node 7
+0.8850464 .000000    !...River 3 Node 1 (Atch - Total River Flow:   cms, Avg Lat/Long: -91.801121,30.979759)
+1.8405100 .000000    !...River 3 Node 2
+1.9783988 .000000    !...River 3 Node 3
+2.1064022 .000000    !...River 3 Node 4
+2.2422078 .000000    !...River 3 Node 5
+2.3578366 .000000    !...River 3 Node 6
+2.3981902 .000000    !...River 3 Node 7
+2.4000970 .000000    !...River 3 Node 8
+2.4138688 .000000    !...River 3 Node 9
+2.4425954 .000000    !...River 3 Node 10
+2.4668434 .000000    !...River 3 Node 11
+2.4747282 .000000    !...River 3 Node 12
+2.4752364 .000000    !...River 3 Node 13
+2.4752462 .000000    !...River 3 Node 14
+2.4731070 .000000    !...River 3 Node 15
+2.4581214 .000000    !...River 3 Node 16
+2.4281474 .000000    !...River 3 Node 17
+2.4046064 .000000    !...River 3 Node 18
+2.3731960 .000000    !...River 3 Node 19
+2.2749594 .000000    !...River 3 Node 20
+2.1125118 .000000    !...River 3 Node 21
+1.0116526 .000000    !...River 3 Node 22

--- a/input/meshes/CPRA24/CPRA24_8kcms_river_flux.txt
+++ b/input/meshes/CPRA24/CPRA24_8kcms_river_flux.txt
@@ -1,0 +1,45 @@
+ STEADY               ! 8kcms CONSTITUENT. 1  ALPHA DESCRIPTOR
+ 0.00000E-00  1.0 0.0   ! CONSTITUENT. 1 FREQ.   NODAL FACTOR   EQUIL. ARG.
+ STEADY       ! ALPHA NUMERIC DESCRIPTION OF ELEVATION BOUNDARY FORCING
+3.4346848 .000000    !...River 1 Node 1 (MS River Total River Flow: 8000.0000 cms, Avg Lat/Long: -91.198941,30.425086)
+7.4134944 .000000    !...River 1 Node 2
+8.3890224 .000000    !...River 1 Node 3
+9.1134544 .000000    !...River 1 Node 4
+9.6244384 .000000    !...River 1 Node 5
+9.8286048 .000000    !...River 1 Node 6
+9.4747120 .000000    !...River 1 Node 7
+8.3061616 .000000    !...River 1 Node 8
+6.4724528 .000000    !...River 1 Node 9
+4.5209968 .000000    !...River 1 Node 10
+2.8911024 .000000    !...River 1 Node 11
+2.0018400 .000000    !...River 1 Node 12
+0.8981392 .000000    !...River 1 Node 13
+0.0000000 .000000    !...River 2 Node 1 (Total River Flow: .0000 cms, Avg Lat/Long: -91.619574,30.776798)
+0.0000000 .000000    !...River 2 Node 2
+0.0000000 .000000    !...River 2 Node 3
+0.0000000 .000000    !...River 2 Node 4
+0.0000000 .000000    !...River 2 Node 5
+0.0000000 .000000    !...River 2 Node 6
+0.0000000 .000000    !...River 2 Node 7
+1.0114816 .000000    !...River 3 Node 1 (Atch - Total River Flow:   cms, Avg Lat/Long: -91.801121,30.979759)
+2.1034400 .000000    !...River 3 Node 2
+2.2610272 .000000    !...River 3 Node 3
+2.4073168 .000000    !...River 3 Node 4
+2.5625232 .000000    !...River 3 Node 5
+2.6946704 .000000    !...River 3 Node 6
+2.7407888 .000000    !...River 3 Node 7
+2.7429680 .000000    !...River 3 Node 8
+2.7587072 .000000    !...River 3 Node 9
+2.7915376 .000000    !...River 3 Node 10
+2.8192496 .000000    !...River 3 Node 11
+2.8282608 .000000    !...River 3 Node 12
+2.8288416 .000000    !...River 3 Node 13
+2.8288528 .000000    !...River 3 Node 14
+2.8264080 .000000    !...River 3 Node 15
+2.8092816 .000000    !...River 3 Node 16
+2.7750256 .000000    !...River 3 Node 17
+2.7481216 .000000    !...River 3 Node 18
+2.7122240 .000000    !...River 3 Node 19
+2.5999536 .000000    !...River 3 Node 20
+2.4142992 .000000    !...River 3 Node 21
+1.1561744 .000000    !...River 3 Node 22

--- a/input/meshes/CPRA24/CPRA24_9kcms_river_flux.txt
+++ b/input/meshes/CPRA24/CPRA24_9kcms_river_flux.txt
@@ -1,0 +1,45 @@
+ STEADY               ! 9kcms CONSTITUENT. 1  ALPHA DESCRIPTOR
+ 0.00000E-00  1.0 0.0   ! CONSTITUENT. 1 FREQ.   NODAL FACTOR   EQUIL. ARG.
+ STEADY       ! ALPHA NUMERIC DESCRIPTION OF ELEVATION BOUNDARY FORCING
+3.86402040 .000000    !...River 1 Node 1 (MS River Total River Flow: 9000.0000 cms, Avg Lat/Long: -91.198941,30.425086)
+8.34018120 .000000    !...River 1 Node 2
+9.43765020 .000000    !...River 1 Node 3
+10.2526362 .000000    !...River 1 Node 4
+10.8274932 .000000    !...River 1 Node 5
+11.0571804 .000000    !...River 1 Node 6
+10.6590510 .000000    !...River 1 Node 7
+9.34443180 .000000    !...River 1 Node 8
+7.28150940 .000000    !...River 1 Node 9
+5.08612140 .000000    !...River 1 Node 10
+3.25249020 .000000    !...River 1 Node 11
+2.25207000 .000000    !...River 1 Node 12
+1.01040660 .000000    !...River 1 Node 13
+0.00000000 .000000    !...River 2 Node 1 (Total River Flow: .0000 cms, Avg Lat/Long: -91.619574,30.776798)
+0.00000000 .000000    !...River 2 Node 2
+0.00000000 .000000    !...River 2 Node 3
+0.00000000 .000000    !...River 2 Node 4
+0.00000000 .000000    !...River 2 Node 5
+0.00000000 .000000    !...River 2 Node 6
+0.00000000 .000000    !...River 2 Node 7
+1.13791680 .000000    !...River 3 Node 1 (Atch - Total River Flow:   cms, Avg Lat/Long: -91.801121,30.979759)
+2.36637000 .000000    !...River 3 Node 2
+2.54365560 .000000    !...River 3 Node 3
+2.70823140 .000000    !...River 3 Node 4
+2.88283860 .000000    !...River 3 Node 5
+3.03150420 .000000    !...River 3 Node 6
+3.08338740 .000000    !...River 3 Node 7
+3.08583900 .000000    !...River 3 Node 8
+3.10354560 .000000    !...River 3 Node 9
+3.14047980 .000000    !...River 3 Node 10
+3.17165580 .000000    !...River 3 Node 11
+3.18179340 .000000    !...River 3 Node 12
+3.18244680 .000000    !...River 3 Node 13
+3.18245940 .000000    !...River 3 Node 14
+3.17970900 .000000    !...River 3 Node 15
+3.16044180 .000000    !...River 3 Node 16
+3.12190380 .000000    !...River 3 Node 17
+3.09163680 .000000    !...River 3 Node 18
+3.05125200 .000000    !...River 3 Node 19
+2.92494780 .000000    !...River 3 Node 20
+2.71608660 .000000    !...River 3 Node 21
+1.30069620 .000000    !...River 3 Node 22

--- a/input/meshes/LAERDC/LAERDC_10kcms_river_flux.txt
+++ b/input/meshes/LAERDC/LAERDC_10kcms_river_flux.txt
@@ -1,0 +1,32 @@
+ STEADY               ! 10kcms CONSTITUENT. 1  ALPHA DESCRIPTOR
+ 0.00000E-00  1.0 0.0   ! CONSTITUENT. 1 FREQ., NODAL FACTOR, EQUIL. ARG.
+  STEADY       ! ALPHA NUMERIC DESCRIPTION OF ELEVATION BOUNDARY FORCING
+1.330180498 .000000    !...River 1 Node 1 (Total River Flow: 10000.0000 cms, Avg Lat/Long: -91.801121,30.979759)
+2.766192859 .000000    !...River 1 Node 2
+2.973434373 .000000    !...River 1 Node 3
+3.165816166 .000000    !...River 1 Node 4
+3.369925446 .000000    !...River 1 Node 5
+3.543710026 .000000    !...River 1 Node 6
+3.604359427 .000000    !...River 1 Node 7
+3.607225819 .000000    !...River 1 Node 8
+3.627924269 .000000    !...River 1 Node 9
+3.671096724 .000000    !...River 1 Node 10
+3.707540710 .000000    !...River 1 Node 11
+3.719391799 .000000    !...River 1 Node 12
+3.720155974 .000000    !...River 1 Node 13
+3.720169708 .000000    !...River 1 Node 14
+3.716955072 .000000    !...River 1 Node 15
+3.694432019 .000000    !...River 1 Node 16
+3.649383951 .000000    !...River 1 Node 17
+3.614002354 .000000    !...River 1 Node 18
+3.566794193 .000000    !...River 1 Node 19
+3.419149500 .000000    !...River 1 Node 20
+3.174998038 .000000    !...River 1 Node 21
+1.520463017 .000000    !...River 1 Node 22
+7.315537571 .000000    !...River 2 Node 1 (Total River Flow:  cms, Avg Lat/Long: -91.573385,31.026883)
+19.84072297 .000000    !...River 2 Node 2
+26.09515499 .000000    !...River 2 Node 3
+22.01340789 .000000    !...River 2 Node 4
+14.03223269 .000000    !...River 2 Node 5
+9.190335491 .000000    !...River 2 Node 6
+3.601542084 .000000    !...River 2 Node 7

--- a/input/meshes/LAERDC/LAERDC_6kcms_river_flux.txt
+++ b/input/meshes/LAERDC/LAERDC_6kcms_river_flux.txt
@@ -1,0 +1,32 @@
+ STEADY               ! 6kcms CONSTITUENT. 1  ALPHA DESCRIPTOR
+ 0.00000E-00  1.0 0.0   ! CONSTITUENT. 1 FREQ., NODAL FACTOR, EQUIL. ARG.
+  STEADY       ! ALPHA NUMERIC DESCRIPTION OF ELEVATION BOUNDARY FORCING
+0.798108299  .000000    !...River 1 Node 1 (Total River Flow: 6000.0000 cms, Avg Lat/Long: -91.801121,30.979759)
+1.659715715  .000000    !...River 1 Node 2
+1.784060624  .000000    !...River 1 Node 3
+1.899489700  .000000    !...River 1 Node 4
+2.021955268  .000000    !...River 1 Node 5
+2.126226015  .000000    !...River 1 Node 6
+2.162615656  .000000    !...River 1 Node 7
+2.164335491  .000000    !...River 1 Node 8
+2.176754562  .000000    !...River 1 Node 9
+2.202658034  .000000    !...River 1 Node 10
+2.224524426  .000000    !...River 1 Node 11
+2.231635079  .000000    !...River 1 Node 12
+2.232093584  .000000    !...River 1 Node 13
+2.232101825  .000000    !...River 1 Node 14
+2.230173043  .000000    !...River 1 Node 15
+2.216659211  .000000    !...River 1 Node 16
+2.189630371  .000000    !...River 1 Node 17
+2.168401413  .000000    !...River 1 Node 18
+2.140076516  .000000    !...River 1 Node 19
+2.051489700  .000000    !...River 1 Node 20
+1.904998823  .000000    !...River 1 Node 21
+0.9122778105 .000000    !...River 1 Node 22
+4.389322543  .000000    !...River 2 Node 1 (Total River Flow:  cms, Avg Lat/Long: -91.573385,31.026883)
+11.90443378  .000000    !...River 2 Node 2
+15.65709300  .000000    !...River 2 Node 3
+13.20804473  .000000    !...River 2 Node 4
+8.419339612  .000000    !...River 2 Node 5
+5.514201295  .000000    !...River 2 Node 6
+2.160925250  .000000    !...River 2 Node 7

--- a/input/meshes/LAERDC/LAERDC_7kcms_river_flux.txt
+++ b/input/meshes/LAERDC/LAERDC_7kcms_river_flux.txt
@@ -1,0 +1,32 @@
+ STEADY               ! 7kcms CONSTITUENT. 1  ALPHA DESCRIPTOR
+ 0.00000E-00  1.0 0.0   ! CONSTITUENT. 1 FREQ., NODAL FACTOR, EQUIL. ARG.
+  STEADY       ! ALPHA NUMERIC DESCRIPTION OF ELEVATION BOUNDARY FORCING
+0.9311263488 .000000    !...River 1 Node 1 (Total River Flow: 7000.0000 cms, Avg Lat/Long: -91.801121,30.979759)
+1.9363350010 .000000    !...River 1 Node 2
+2.0814040610 .000000    !...River 1 Node 3
+2.2160713160 .000000    !...River 1 Node 4
+2.3589478120 .000000    !...River 1 Node 5
+2.4805970180 .000000    !...River 1 Node 6
+2.5230515990 .000000    !...River 1 Node 7
+2.5250580730 .000000    !...River 1 Node 8
+2.5395469880 .000000    !...River 1 Node 9
+2.5697677060 .000000    !...River 1 Node 10
+2.5952784970 .000000    !...River 1 Node 11
+2.6035742590 .000000    !...River 1 Node 12
+2.6041091820 .000000    !...River 1 Node 13
+2.6041187950 .000000    !...River 1 Node 14
+2.6018685500 .000000    !...River 1 Node 15
+2.5861024130 .000000    !...River 1 Node 16
+2.5545687660 .000000    !...River 1 Node 17
+2.5298016480 .000000    !...River 1 Node 18
+2.4967559350 .000000    !...River 1 Node 19
+2.3934046500 .000000    !...River 1 Node 20
+2.2224986270 .000000    !...River 1 Node 21
+1.0643241120 .000000    !...River 1 Node 22
+5.1208763000 .000000    !...River 2 Node 1 (Total River Flow:  cms, Avg Lat/Long: -91.573385,31.026883)
+13.888506080 .000000    !...River 2 Node 2
+18.266608500 .000000    !...River 2 Node 3
+15.409385520 .000000    !...River 2 Node 4
+9.8225628800 .000000    !...River 2 Node 5
+6.4332348440 .000000    !...River 2 Node 6
+2.5210794590 .000000    !...River 2 Node 7

--- a/input/meshes/LAERDC/LAERDC_8kcms_river_flux.txt
+++ b/input/meshes/LAERDC/LAERDC_8kcms_river_flux.txt
@@ -1,0 +1,32 @@
+ STEADY               ! 8kcms CONSTITUENT. 1  ALPHA DESCRIPTOR
+ 0.00000E-00  1.0 0.0   ! CONSTITUENT. 1 FREQ., NODAL FACTOR, EQUIL. ARG.
+  STEADY       ! ALPHA NUMERIC DESCRIPTION OF ELEVATION BOUNDARY FORCING
+1.064144399 .000000    !...River 1 Node 1 (Total River Flow: 8000.0000 cms, Avg Lat/Long: -91.801121,30.979759)
+2.212954287 .000000    !...River 1 Node 2
+2.378747499 .000000    !...River 1 Node 3
+2.532652933 .000000    !...River 1 Node 4
+2.695940357 .000000    !...River 1 Node 5
+2.834968020 .000000    !...River 1 Node 6
+2.883487542 .000000    !...River 1 Node 7
+2.885780655 .000000    !...River 1 Node 8
+2.902339415 .000000    !...River 1 Node 9
+2.936877379 .000000    !...River 1 Node 10
+2.966032568 .000000    !...River 1 Node 11
+2.975513439 .000000    !...River 1 Node 12
+2.976124779 .000000    !...River 1 Node 13
+2.976135766 .000000    !...River 1 Node 14
+2.973564057 .000000    !...River 1 Node 15
+2.955545615 .000000    !...River 1 Node 16
+2.919507161 .000000    !...River 1 Node 17
+2.891201883 .000000    !...River 1 Node 18
+2.853435354 .000000    !...River 1 Node 19
+2.735319600 .000000    !...River 1 Node 20
+2.539998430 .000000    !...River 1 Node 21
+1.216370414 .000000    !...River 1 Node 22
+5.852430057 .000000    !...River 2 Node 1 (Total River Flow:  cms, Avg Lat/Long: -91.573385,31.026883)
+15.87257838 .000000    !...River 2 Node 2
+20.87612399 .000000    !...River 2 Node 3
+17.61072631 .000000    !...River 2 Node 4
+11.22578615 .000000    !...River 2 Node 5
+7.352268393 .000000    !...River 2 Node 6
+2.881233667 .000000    !...River 2 Node 7

--- a/input/meshes/LAERDC/LAERDC_9kcms_river_flux.txt
+++ b/input/meshes/LAERDC/LAERDC_9kcms_river_flux.txt
@@ -1,0 +1,32 @@
+ STEADY               ! 9kcms CONSTITUENT. 1  ALPHA DESCRIPTOR
+ 0.00000E-00  1.0 0.0   ! CONSTITUENT. 1 FREQ., NODAL FACTOR, EQUIL. ARG.
+  STEADY       ! ALPHA NUMERIC DESCRIPTION OF ELEVATION BOUNDARY FORCING
+1.197162448 .000000    !...River 1 Node 1 (Total River Flow: 9000.0000 cms, Avg Lat/Long: -91.801121,30.979759)
+2.489573573 .000000    !...River 1 Node 2
+2.676090936 .000000    !...River 1 Node 3
+2.849234550 .000000    !...River 1 Node 4
+3.032932902 .000000    !...River 1 Node 5
+3.189339023 .000000    !...River 1 Node 6
+3.243923484 .000000    !...River 1 Node 7
+3.246503237 .000000    !...River 1 Node 8
+3.265131842 .000000    !...River 1 Node 9
+3.303987051 .000000    !...River 1 Node 10
+3.336786639 .000000    !...River 1 Node 11
+3.347452619 .000000    !...River 1 Node 12
+3.348140377 .000000    !...River 1 Node 13
+3.348152737 .000000    !...River 1 Node 14
+3.345259564 .000000    !...River 1 Node 15
+3.324988817 .000000    !...River 1 Node 16
+3.284445556 .000000    !...River 1 Node 17
+3.252602119 .000000    !...River 1 Node 18
+3.210114773 .000000    !...River 1 Node 19
+3.077234550 .000000    !...River 1 Node 20
+2.857498234 .000000    !...River 1 Node 21
+1.368416716 .000000    !...River 1 Node 22
+6.583983814 .000000    !...River 2 Node 1 (Total River Flow:  cms, Avg Lat/Long: -91.573385,31.026883)
+17.85665068 .000000    !...River 2 Node 2
+23.48563949 .000000    !...River 2 Node 3
+19.81206710 .000000    !...River 2 Node 4
+12.62900942 .000000    !...River 2 Node 5
+8.271301942 .000000    !...River 2 Node 6
+3.241387875 .000000    !...River 2 Node 7


### PR DESCRIPTION
### Summary

This pull request adds new steady-state river flux template files for two ADCIRC-compatible meshes used in ASGS runs:

- `CPRA24`
- `LAERDC`

Each file represents a different total river inflow condition, ranging from **6kcms to 10kcms**, and defines **elevation boundary conditions** for river nodes in steady simulations. These files are designed to be included during runtime when ASGS generates the final `fort.15` file for a particular storm hindcast or forecast.

---

### Purpose

The primary goal of this contribution is to provide **pre-generated river flux files** for various total inflow scenarios (6–10kcms), so that they are readily available during major storm events without needing to search for or regenerate them under time pressure.

These files are designed to be used by **ASGS during runtime**, where they are automatically inserted into the final `fort.15` using the standard templating system. Each file includes:
- A clear flow label in the descriptor (e.g., `10kcms CONSTITUENT`)
- A metadata comment on the first node indicating the total intended river discharge

This ensures that the final `fort.15` used in the simulation **retains a visible record** of the boundary condition flow scenario, which is crucial for transparency, reproducibility, and rapid analysis during or after storm events.

---

### Implementation Details

- **Top metadata line** (e.g. `! 10kcms CONSTITUENT`) and the first node’s comment line explicitly indicate the **intended total river inflow** (e.g. `10000.0000 cms`) for clarity.
- **Only the Mississippi River (River 1)** has verified discharge metadata, based on observed gauge elevation-to-discharge relationships.
- **Atchafalaya River and others** have placeholder or blank `Total River Flow:` comments to avoid introducing unscientific assumptions. These can be filled in later if calibration data becomes available.
- The formatting is compatible with ASGS template handling. When a custom river flux file is specified, ASGS will substitute this content directly into the `fort.15` using predefined placeholders, ensuring correct initialization of elevation boundary conditions.

---

### Files Added

#### CPRA24 Mesh
- `CPRA24_7kcms_river_flux.txt`
- `CPRA24_8kcms_river_flux.txt`
- `CPRA24_9kcms_river_flux.txt`
- `CPRA24_10kcms_river_flux.txt`

#### LAERDC Mesh
- `LAERDC_6kcms_river_flux.txt`
- `LAERDC_7kcms_river_flux.txt`
- `LAERDC_8kcms_river_flux.txt`
- `LAERDC_9kcms_river_flux.txt`
- `LAERDC_10kcms_river_flux.txt`

---

Please let me know if you'd like to look for it, or even better if you know what the Atchafalaya (CPRA24 Mesh) or River 2 (LAERDC Mesh)  relationship is to Mississippi River to complete metadata/comments coverage.
