### PR TITLE
Explicitly disable GSL for NCO.

### DIFF
--- a/cloud/general/init-nco.sh
+++ b/cloud/general/init-nco.sh
@@ -39,7 +39,7 @@ if [ ! -e $OPT/bin/ncks ]; then
    echo $OPT/bin/ncks was not found
    tar zxvf ./$NCO_TGZ
    cd $NCO_DIR
-   ./configure --prefix=$OPT
+   ./configure --prefix=$OPT --enable-gsl=no
    make -j $JOBS
    make install
 fi


### PR DESCRIPTION
Issue 1515: Adds --enable-gsl=no to the ./configure step, thus unshackling us from the tyranny of an unnecessary dependency.

Resolves #1515.