### PR TITLE
Adding support for a local Debian cluster with Slurm

### DIFF
--- a/platforms/debian+slurm/about.txt
+++ b/platforms/debian+slurm/about.txt
@@ -1,0 +1,1 @@
+Debian and Debian-based OSes Clusters + Slurm

--- a/platforms/debian+slurm/init.sh
+++ b/platforms/debian+slurm/init.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Needed for ./init-asgs.sh, bin/guess
+export WORK=${WORK:-$HOME/work}
+export SCRATCH=${SCRATCH:-$HOME/scratch}
+export DEFAULT_COMPILER=gfortran
+export HPCENV=debian.cluster
+export HPCENVSHORT=debian
+export QUEUESYS=SLURM
+export QCHECKCMD=squeue
+export SUBMITSTRING=sbatch
+export ARCHIVE=enstorm_pedir_removal.sh
+export ARCHIVEBASE=$SCRATCH
+export ARCHIVEDIR=$SCRATCH
+export OPENDAPPOST=opendap_post2.sh
+export TDS=()
+export MAKEJOBS=2
+
+export QSUMMARYCMD=squeue
+export QUOTACHECKCMD=null
+export ALLOCCHECKCMD=null
+export QUEUENAME=general
+export SERQUEUE=general
+export ACCOUNT=null
+export JOBLAUNCHER='srun -N %nnodes%'
+export PPN=28 # this will vary wildly from cluster to cluster


### PR DESCRIPTION
Issue-1525: This commit adds support for local debian clusters that use slurm to manage job submissions, in particular the ADCIRC compute clusters that ADCIRC Live (C) builds and supports.

Resolves #1525