### PR TITLE
Added scp and ssh links to the opendap_post2 emails

### DIFF
--- a/output/opendap_post2.sh
+++ b/output/opendap_post2.sh
@@ -423,6 +423,14 @@ The run.properties file is : $DOWNLOADPREFIX/$STORMNAMEPATH/$OPENDAPSUFFIX/run.p
 or wget the file with the following command
 
 wget $DOWNLOADPREFIX/$STORMNAMEPATH/$OPENDAPSUFFIX/run.properties
+
+or download over scp with the following command
+
+scp $OPENDAPHOST:$OPENDAPDIR/run.properties .
+
+or list contents
+
+ssh $OPENDAPHOST "ls $OPENDAPDIR"
 END
 
    fi


### PR DESCRIPTION
Issue 1628: This offers additional options to view and retrieve files on opendap and thredds servers via ssh and scp.

Resolves #1628