### PR TITLE
Fixing oversight - Template rendering failed with MEMPERCPU not defined.

### DIFF
--- a/qscript.pl
+++ b/qscript.pl
@@ -162,7 +162,7 @@ $jshash_ref->{cmd} = $cmd;
 $jshash_ref->{cmdLineOptions} = $cloptions;
 $jshash_ref->{totalcpu} = $totalcpu;
 $jshash_ref->{nnodes} = $nnodes;
-$jshash_ref->{mempercpu} = $ENV{MEMPERCPU} // undef;
+$jshash_ref->{mempercpu} = $ENV{MEMPERCPU} // "";
 
 TEMPLATE_RENDER:
 while(my $line = <$TEMPLATE>) {

--- a/qscript.template
+++ b/qscript.template
@@ -26,7 +26,7 @@
 #SBATCH --qos=%qos%
 [%# Note: this section is processed by Template Toolkit in qscript.pl -%]
 [%# Note: TODO: update entire template to use Template Toolkit syntax -%]
-[% IF runinfo.parallelism == "serial" AND runinfo.mempercpu.defined -%]
+[% IF runinfo.parallelism == "serial" AND runinfo.mempercpu -%]
 #SBATCH --mem-per-cpu=[% runinfo.mempercpu %]
 [% END -%]
 #SBATCH --output=%advisdir%/%scenario%/%jobtype%.out


### PR DESCRIPTION
Issue-1635: We're using Template Toolkit in "strict" mode, but this fix is necessary because I didn't test when "MEMPERCPU" was not defined - which is the case currently with most supported platforms.

Related to #1635.