### PR TITLE
Adding QBD to the list of platforms where SERQUEUE_NTASKS is supported

### DIFF
--- a/platforms.sh
+++ b/platforms.sh
@@ -381,8 +381,15 @@ HPC_PPN_Hint()
        echo $DEFAULT_PPN
      fi
    ;;
+   "qbd.loni.org")
+     if [[ "$QUEUEKIND" == "serial" ]]; then
+       echo $SERQUEUE_NTASKS # this is defined above
+     else
+       echo $DEFAULT_PPN
+     fi
+   ;;
    "mike.hpc.lsu.edu")
-   if [[ "$QUEUENAME" == "single" && "$CPUREQUEST" -lt 64 ]]; then
+     if [[ "$QUEUENAME" == "single" && "$CPUREQUEST" -lt 64 ]]; then
        echo $CPUREQUEST
      else
        echo $DEFAULT_PPN

--- a/platforms/queenbeeD/init.sh
+++ b/platforms/queenbeeD/init.sh
@@ -7,6 +7,7 @@ export QUEUESYS=SLURM
 export QCHECKCMD=sacct
 export QUEUENAME=workq
 export SERQUEUE=single
+export SERQUEUE_NTASKS=3 # 12G for slurm, $SERQUEUE_NTASKS * 4G, applied to --ntasks
 export WORK=${WORK:-/work/$USER}
 export SCRATCH=${SCRATCH:-/work/$USER}
 export JOBLAUNCHER='srun '


### PR DESCRIPTION
Issue 1635: Adding QBD, this also allows SERQUEUE_NTASKS for QBD to be updated in the ASGS configuration file being used in the situation that the OOM is happening.

Related to #1635.