### PR TITLE
Adding support for bc if it is not found on the platform

### DIFF
--- a/cloud/general/asgs-brew.pl
+++ b/cloud/general/asgs-brew.pl
@@ -1150,6 +1150,31 @@ sub get_steps {
             },
         },
         {
+            key         => q{bc},
+            name        => q{Step for installing bc and dc},
+            description => q{Install bc for shell-based floating point calculations},
+            pwd         => qq{$scriptdir},
+            command     => qq{bash ./cloud/general/init-bc.sh $asgs_install_path},
+            clean       => qq{bash ./cloud/general/init-bc.sh $asgs_install_path clean},
+            skip_if     => sub {
+                local $?;
+                system(qq{bc --version > /dev/null 2>&1});
+
+                # look for zero exit code on success
+                my $exit_code = ( $? >> 8 );
+                return ( defined $exit_code and $exit_code == 0 ) ? 1 : 0;
+            },
+            precondition_check  => sub { 1 },
+            postcondition_check => sub {
+                local $?;
+                system(qq{$asgs_install_path/bin/bc --version > /dev/null 2>&1});
+
+                # look for zero exit code on success
+                my $exit_code = ( $? >> 8 );
+                return ( defined $exit_code and $exit_code == 0 ) ? 1 : 0;
+            },
+        },
+        {
             key         => q{asgs-lint},
             name        => q{Step for installing asgs-lint},
             description => q{Install asgs-lint, linter for ASGS configuration files},

--- a/cloud/general/init-bc.sh
+++ b/cloud/general/init-bc.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+OPT=${1:-$ASGS_INSTALL_PATH}
+COMPILER=$2
+JOBS=${3:-1}
+
+_ASGS_TMP=${ASGS_TMPDIR:-/tmp/${USER}-asgs}
+
+mkdir -p $_ASGS_TMP 2> /dev/null
+chmod 700 $_ASGS_TMP
+
+if [[ "$COMPILER" == "clean" || "$COMPILER" == "rebuild" ]]; then
+  echo cleaning bc
+  pushd $OPT > /dev/null 2>&1
+  rm -vf ./bin/bc
+  rm -vf ./bin/dc
+  popd $OPT > /dev/null 2>&1
+  echo cleaning bc build scripts and downloads
+  cd $_ASGS_TMP
+  rm -vrf ${BC_DIR}* > /dev/null 2>&1
+
+  # stop here if 'clean', proceed if 'rebuild'
+  if [ "$COMPILER" == "clean" ]; then
+    exit
+  fi
+fi
+
+if [ -x ${OPT}/bin/bc ]; then
+  printf "(warn) 'bc' was found in $OPT/bin/bc; to rebuild run,\n\n\tbuild bc rebuild\n\n"
+  exit
+fi
+
+BC_VERSION=1.08.2
+BC_DIR=bc-${BC_VERSION}
+BC_TGZ=${BC_DIR}.tar.gz
+cd $_ASGS_TMP
+
+if [ ! -e ${BC_TGZ} ]; then
+  wget -4 https://ftp.gnu.org/gnu/bc/${BC_TGZ}
+fi
+
+rm -rf ./$BC_DIR 2> /dev/null
+
+tar zxvf ./$BC_TGZ
+
+cd $BC_DIR
+./configure --prefix $ASGS_INSTALL_PATH
+make -C lib        && \
+make -C bc install && \
+make -C dc install
+
+# no errors, so clean up
+if [ "$?" == 0 ]; then
+  echo ...cleaning build scripts and downloads
+  cd $_ASGS_TMP
+  rm -rfv ${BC_DIR}* > /dev/null 2>&1
+  echo
+  echo "Installation of 'bc' appears to have gone well"
+  printf "Output of 'which bc':\n\n\t%s\n" $(which bc)
+  echo
+fi


### PR DESCRIPTION
Issue 1691: bc and dc (same tarball) will be installed during ASGS' install if it is not found on the system. It is present on most machines, but modern Linux distros seem to be removing older utilities.

Resolves #1691.