### PR TITLE
Add option to `fetch` to force using ssh to clone

### DIFF
--- a/bin/fetch
+++ b/bin/fetch
@@ -1,5 +1,32 @@
 #!/usr/bin/env bash
 
+ITEM=${1}
+
+shift
+
+FORCE_SSH=0
+FORCE_HTTPS=0
+
+# parse remaining optional flags
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force-ssh)
+      FORCE_SSH=1
+      ;;
+    --force-https)
+      FORCE_HTTPS=1
+      ;;
+    *)
+      ;;
+  esac
+  shift
+done
+
+if [[ $FORCE_SSH -eq 1 && $FORCE_HTTPS -eq 1 ]]; then
+  echo "--force-ssh and --force-https are mutually exclusive"
+  exit 1
+fi
+
 if [ -z "$_ASGSH_PID" ]; then
   SCRIPTDIR=$2
   if [ -z "$SCRIPTDIR" ]; then
@@ -13,12 +40,30 @@ fi
 # for all "git clone" calls here - solves issue of there being not
 # key set up prior to adcirclive installation
 set_gitprotocol_repo() {
-  BASEURL="https://github.com/" # terminal character (/) matters 
+
+  # force git/ssh
+  if [[ $FORCE_SSH -eq 1 ]]; then
+    BASEURL="git@github.com:" # terminal character (:) matters
+    echo "forcing git@github.com protocol ..."
+    return
+  fi
+
+  # force https
+  if [[ $FORCE_HTTPS -eq 1 ]]; then
+    BASEURL="https://github.com/" # terminal character (/) matters
+    echo "forcing https://github.com protocol ..."
+    return
+  fi
+
+  # auto detect
+  BASEURL="https://github.com/" # terminal character (/) matters
+
   local check=$(git remote -v 2> /dev/null | grep -c "git@github")
+
   if [ "$check" -gt 0 ]; then
     BASEURL="git@github.com:" # terminal character (:) matters
   else
-    echo using default https to clone or update repo ...
+    echo "using default https to clone or update repo ..."
   fi
 }
 
@@ -26,8 +71,6 @@ set_gitprotocol_repo() {
 # point
 
 set_gitprotocol_repo
-
-ITEM=${1}
 
 case "${ITEM}" in
   all)

--- a/bin/regit
+++ b/bin/regit
@@ -11,7 +11,7 @@ fi
 
 VERSION_REF=$(tr -d '[:space:]' < ./VERSION)
 
-if [[ "$VERSION_REF" == "development"]]; then
+if [[ "$VERSION_REF" == "development" ]]; then
   VERSION_REF=master
 fi
 

--- a/bin/regit
+++ b/bin/regit
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+if [ -z "$_ASGSH_PID" ]; then
+  SCRIPTDIR=$2
+  if [ -z "$SCRIPTDIR" ]; then
+    echo "If this script is not run inside of the ASGS Shell Environment, asgsh."
+    echo "the path of the SCRIPTDIR must be provided as the second argument ..."
+    exit 1
+  fi
+fi
+
+VERSION_REF=$(tr -d '[:space:]' < ./VERSION)
+
+# refuse to reinitialize an existing git repo
+if [[ -e .git ]]; then
+  echo "ERROR: Git repository metadata already exists; refusing to reinitialize repository."
+  exit 1
+fi
+
+echo "Reconnecting extracted release tree to git ref '$VERSION_REF' ..."
+
+git init 2> /dev/null || exit 1
+
+git remote add origin git@github.com:StormSurgeLive/asgs.git || exit 1
+
+git fetch origin --tags || exit 1
+
+# determine whether VERSION refers to a branch or tag
+if git rev-parse --verify --quiet "origin/$VERSION_REF" >/dev/null; then
+  TARGET_REF="origin/$VERSION_REF"
+  LOCAL_BRANCH="$VERSION_REF"
+
+elif git rev-parse --verify --quiet "refs/tags/$VERSION_REF" >/dev/null; then
+  TARGET_REF="$VERSION_REF"
+  LOCAL_BRANCH="release-$VERSION_REF"
+
+else
+  echo "ERROR: VERSION ref '$VERSION_REF' not found on origin"
+  exit 1
+fi
+
+git checkout -B "$LOCAL_BRANCH" "$TARGET_REF" --force || exit 1
+
+git reset --hard "$TARGET_REF" || exit 1
+
+echo "Repository successfully reconnected to '$TARGET_REF'."

--- a/bin/regit
+++ b/bin/regit
@@ -11,6 +11,10 @@ fi
 
 VERSION_REF=$(tr -d '[:space:]' < ./VERSION)
 
+if [[ "$VERSION_REF" == "development"]]; then
+  VERSION_REF=master
+fi
+
 # refuse to reinitialize an existing git repo
 if [[ -e .git ]]; then
   echo "ERROR: Git repository metadata already exists; refusing to reinitialize repository."


### PR DESCRIPTION
Issue-1700: When using a "release" tar.gz or zip, bin/fetch will fallback to using the https protocol for cloning supported repositories; this commit adds an option, --force-ssh, to force ssh; if for some reason a user needs to force https, there is also the option to --force-https.

Example,

  asgs-shell>fetch cera # may default to https authentication

so instead, do:

  asgs-shell>fetch cera --force-ssh # now uses the ssh key that should be present

Resolves #1700.