### PR TITLE
Formalizing v53.05.live.0 as a separate LTS version.

### DIFF
--- a/cloud/general/t/build-all-adcirc.sh
+++ b/cloud/general/t/build-all-adcirc.sh
@@ -13,6 +13,7 @@ if ! command -v init-adcirc.sh >/dev/null 2>&1; then
 fi
 
 versions=(
+  v53.05.live.0
   v53release
   v55.01-5bc04d6
   v55.02

--- a/patches/ADCIRC/v53.05.live.0/01-cmplrflags-mk.patch
+++ b/patches/ADCIRC/v53.05.live.0/01-cmplrflags-mk.patch
@@ -1,0 +1,688 @@
+diff --git a/work/cmplrflags.mk b/work/cmplrflags.mk
+index 2c0eb06..b4a5c15 100644
+--- a/work/cmplrflags.mk
++++ b/work/cmplrflags.mk
+@@ -11,6 +11,7 @@ ifeq ($(MACHINE)-$(OS),i686-mingw32)
+ #
+ compiler=gnu
+ ifeq ($(compiler),gnu)
++  GCC_VERSION   := $(shell gfortran -dumpversion)
+   PPFC		:=  gfortran
+   FC		:=  gfortran
+   PFC		:=  mpif90
+@@ -89,13 +90,10 @@ ifeq ($(compiler),gnu)
+   MSGLIBS	:=
+   ifeq ($(NETCDF),enable)
+      ifeq ($(MACHINENAME),blueridge)
+-        # FLIBS       := $(FLIBS) -L$(HDF5HOME) -lhdf5  
+-        NETCDFHOME    :=/usr
++        # FLIBS       := $(FLIBS) -L$(HDF5HOME) -lhdf5
+         FFLAGS1       :=$(FFLAGS1) -I/usr/lib64/gfortran/modules
+         FFLAGS2       :=$(FFLAGS1)
+         FFLAGS3       :=$(FFLAGS1)
+-        # NETCDFHOME  :=/shared/apps/RHEL-5/x86_64/NetCDF/netcdf-4.1.1-gcc4.1-ifort
+-        # NETCDFHOME  :=/shared/apps/RHEL-5/x86_64/NetCDF/netcdf-4.1.2-gcc4.1-ifort
+         FLIBS          :=$(FLIBS) -L/usr/lib64 -lnetcdff
+      else
+         FLIBS          := $(FLIBS) -L$(HDF5HOME) -lhdf5 -lhdf5_fortran
+@@ -117,18 +115,18 @@ ifeq ($(compiler),gfortran)
+   PPFC		:=  gfortran
+   FC		:=  gfortran
+   PFC		:=  mpif90
+-  FFLAGS1	:=  $(INCDIRS) -O2 -ffixed-line-length-none 
++  FFLAGS1	:=  $(INCDIRS) -O2 -ffixed-line-length-none
+   ifeq ($(PROFILE),enable)
+-    FFLAGS1	:=  $(INCDIRS) -pg -O0 -fprofile-arcs -ftest-coverage -ffixed-line-length-none 
++    FFLAGS1	:=  $(INCDIRS) -pg -O0 -fprofile-arcs -ftest-coverage -ffixed-line-length-none
+   endif
+   ifeq ($(DEBUG),full)
+-    FFLAGS1	:=  $(INCDIRS) -g -O0 -ffixed-line-length-none -fbacktrace -fbounds-check -ffpe-trap=zero,invalid,overflow,denormal -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK -DDEBUG_HOLLAND -DDEBUG_WARN_ELEV
++    FFLAGS1	:=  $(INCDIRS) -g -O0 -ffixed-line-length-none -fbacktrace -fbounds-check -ffpe-trap=zero,invalid,overflow,denormal -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK -DDEBUG_HOLLAND
+   endif
+   ifeq ($(DEBUG),compiler-warnings)
+     FFLAGS1	:=  $(INCDIRS) -g -O0 -Wall -Wextra -ffixed-line-length-none -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK
+   endif
+   ifeq ($(DEBUG),full-not-warnelev)
+-    FFLAGS1	:=  $(INCDIRS) -g -O0 -ffixed-line-length-none -fbacktrace -fbounds-check -ffpe-trap=zero,invalid,overflow,denormal -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK -DDEBUG_HOLLAND 
++    FFLAGS1	:=  $(INCDIRS) -g -O0 -ffixed-line-length-none -fbacktrace -fbounds-check -ffpe-trap=zero,invalid,overflow,denormal -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK -DDEBUG_HOLLAND
+   endif
+   ifeq ($(DEBUG),full-not-fpe)
+     FFLAGS1	:=  $(INCDIRS) -g -O0 -ffixed-line-length-none -fbacktrace -fbounds-check -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK -DDEBUG_HOLLAND
+@@ -147,16 +145,16 @@ ifeq ($(compiler),gfortran)
+   ifeq ($(SWAN),enable)
+      DPRE               :=  -DREAL8 -DLINUX -DADCSWAN
+   endif
+-  FLIBS         := 
++  FLIBS         :=
+   ifeq ($(NETCDF),enable)
+-     ifeq ($(MACHINENAME),penguin)    
++     ifeq ($(MACHINENAME),penguin)
+         # module purge
+-        # module load gcc/6.2.0 openmpi/2.1.2/gcc.6.2.0 
++        # module load gcc/6.2.0 openmpi/2.1.2/gcc.6.2.0
+         # curl -O ftp://ftp.unidata.ucar.edu/pub/netcdf/old/netcdf-4.2.1.1.tar.gz
+         # curl -O ftp://ftp.unidata.ucar.edu/pub/netcdf/old/netcdf-fortran-4.2.tar.gz
+         # curl -O https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.8/hdf5-1.8.12/src/hdf5-1.8.12.tar.gz
+         # CPPFLAGS=-I/home/jgflemin/local/include LDFLAGS=-L/home/jgflemin/local/lib ./configure --prefix=/home/jgflemin/local
+-        # 
++        #
+         # export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HOME}/local/lib
+         # export PATH=${PATH}:${HOME}/local/bin
+         NETCDFHOME := ${HOME}/local
+@@ -164,20 +162,20 @@ ifeq ($(compiler),gfortran)
+         FFLAGS2 := $(FFLAGS2) -I${HOME}/local/include
+         FFLAGS3 := $(FFLAGS3) -I${HOME}/local/include
+         FLIBS := $(FLIBS) -L${HOME}/local/lib -lnetcdff -lnetcdf
+-     endif 
++     endif
+      ifeq ($(MACHINENAME),jason-desktop)
+         NETCDFHOME := /usr
+         FFLAGS1 := $(FFLAGS1) -L/usr/lib/x86_64-linux-gnu
+         FFLAGS2 := $(FFLAGS2) -L/usr/lib/x86_64-linux-gnu
+         FFLAGS3 := $(FFLAGS3) -L/usr/lib/x86_64-linux-gnu
+      endif
+-     ifeq ($(MACHINENAME),rostam)    
++     ifeq ($(MACHINENAME),rostam)
+         NETCDFHOME := /usr
+-        FFLAGS1 := $(FFLAGS1) -I/usr/lib64/gfortran/modules
+-        FFLAGS2 := $(FFLAGS2) -I/usr/lib64/gfortran/modules
+-        FFLAGS3 := $(FFLAGS3) -I/usr/lib64/gfortran/modules
++        FFLAGS1 := $(FFLAGS1) -I/usr/lib64/gfortran/modules -fallow-argument-mismatch
++        FFLAGS2 := $(FFLAGS2) -I/usr/lib64/gfortran/modules -fallow-argument-mismatch
++        FFLAGS3 := $(FFLAGS3) -I/usr/lib64/gfortran/modules -fallow-argument-mismatch
+      endif
+-     FLIBS      := $(FLIBS) -lnetcdff 
++     FLIBS      := $(FLIBS) -lnetcdff
+   endif
+   IMODS 	:=  -I
+   CC		:= gcc
+@@ -194,13 +192,23 @@ ifeq ($(compiler),gfortran)
+   else
+      MULTIPLE := TRUE
+   endif
++  # Check GCC version for -fallow-argument-mismatch flag (needed for GCC >= 10.1)
++  GCC_VER_MAJOR := $(shell $(FC) -dumpversion | cut -f1 -d.)
++  GCC_VER_MINOR := $(shell $(FC) -dumpversion | cut -f2 -d.)
++
++  ifeq ($(shell test $(GCC_VER_MAJOR) -gt 10 || (test $(GCC_VER_MAJOR) -eq 10 && test $(GCC_VER_MINOR) -ge 1) && echo 1), 1)
++    $(info GCC $(GCC_VER_MAJOR).$(GCC_VER_MINOR) detected - adding -fallow-argument-mismatch flag)
++    FFLAGS1 += -fallow-argument-mismatch
++    FFLAGS2 += -fallow-argument-mismatch
++    FFLAGS3 += -fallow-argument-mismatch
++  endif
+ endif
+ #
+ ifeq ($(compiler),g95)
+   PPFC		:=  g95
+   FC		:=  g95
+   PFC		:=  mpif90
+-  FFLAGS1	:=  $(INCDIRS) -O3 -mcmodel=medium -fstatic -ffixed-line-length-132
++  FFLAGS1	:=  $(INCDIRS) -O2 -mcmodel=medium -fstatic -ffixed-line-length-132
+   FFLAGS2	:=  $(FFLAGS1)
+   FFLAGS3	:=  $(FFLAGS1)
+   DA		:=  -DREAL8 -DLINUX -DCSCA
+@@ -222,14 +230,32 @@ ifeq ($(compiler),g95)
+ endif
+ #
+ # jgf45.12 These flags work on the UNC Topsail Cluster.
+-# jgf: The -i-dynamic flag defers the inclusion of the library with 
++# jgf: The -i-dynamic flag defers the inclusion of the library with
+ # feupdateenv until run time, thus avoiding the error message:
+ # "feupdateenv is not implemented and will always fail"
+-ifeq ($(compiler),intel)
+-  PPFC            :=  ifort
+-  FC            :=  ifort
+-  PFC           :=  mpif90
+-  FFLAGS1       :=  $(INCDIRS) -O2 -FI -assume byterecl -132 -xSSE4.2 -assume buffered_io
++# this line is to support icc/ifort and icx/ifort (llvm based)
++ifneq (,$(filter intel intel-oneapi,$(compiler)))
++  CC   := icc
++  PPFC := ifort
++  FC   := ifort
++  PFC  := mpiifort
++
++  ifeq ($(filter intel-oneapi,$(compiler)),$(compiler))
++    CC := icx
++
++    ifeq ($(shell command -v mpiifx >/dev/null 2>&1 && echo yes),yes)
++      PPFC := ifx
++      FC   := ifx
++      PFC  := mpiifx
++    else ifeq ($(shell command -v mpiifort >/dev/null 2>&1 && echo yes),yes)
++      PPFC := ifort
++      FC   := ifort
++      PFC  := mpiifort
++    else
++      $(error Neither mpiifx nor mpiifort was found in PATH)
++    endif
++  endif
++  FFLAGS1       := $(INCDIRS) -O2 -FI -assume byterecl -132 -xSSE4.2
+   CFLAGS        := $(INCDIRS) -O2 -xSSE4.2 -m64 -mcmodel=medium -DLINUX
+   FLIBS         :=
+   ifeq ($(DEBUG),full)
+@@ -248,45 +274,142 @@ ifeq ($(compiler),intel)
+      FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -DNETCDF_TRACE -DFULL_STACK -DFLUSH_MESSAGES
+   endif
+   #
+-  ifeq ($(MACHINENAME),stampede2) 
+-     FFLAGS1 := $(INCDIRS) -O3 -FI -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 -assume buffered_io
+-     CFLAGS  := $(INCDIRS) -O3 -DLINUX -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 
+-     FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 
++  ifeq ($(MACHINENAME),stampede2)
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
++     FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
+      ifeq ($(DEBUG),trace)
+-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 -assume buffered_io
+-        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 
+-        FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512 
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
++        FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,MIC-AVX512
+      endif
+   endif
+-  ifeq ($(MACHINENAME),frontera) 
+-     FFLAGS1 := $(INCDIRS) -O3 -FI -assume byterecl -132 -xCORE-AVX512 -assume buffered_io
+-     CFLAGS  := $(INCDIRS) -O3 -DLINUX -xCORE-AVX512 
+-     FLIBS   := $(INCDIRS) -xCORE-AVX512 
++  ifeq ($(MACHINENAME),frontera)
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xCORE-AVX512
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX512
++     FLIBS   := $(INCDIRS) -xCORE-AVX512
+      ifeq ($(DEBUG),trace)
+-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX512 -assume buffered_io
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX512
+         CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX512
+-        FLIBS   := $(INCDIRS) -xCORE-AVX512 
++        FLIBS   := $(INCDIRS) -xCORE-AVX512
++     endif
++  endif
++  ifeq ($(MACHINENAME),queenbee)
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xSSE4.2
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xSSE4.2
++     FLIBS   := $(INCDIRS) -xSSE4.2
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xSSE4.2
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xSSE4.2
++        FLIBS   := $(INCDIRS) -xSSE4.2
++     endif
++  endif
++  ifeq ($(MACHINENAME),queenbeeC)
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xCORE-AVX512
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX512
++     FLIBS   := $(INCDIRS) -xCORE-AVX512
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX512
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX512
++        FLIBS   := $(INCDIRS) -xCORE-AVX512
++     endif
++  endif
++  ifeq ($(MACHINENAME),queenbeeD)
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xAVX
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xAVX
++     FLIBS   := $(INCDIRS) -xAVX
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xAVX
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX
++        FLIBS   := $(INCDIRS) -xAVX
++     endif
++  endif
++  ifeq ($(MACHINENAME),supermic)
++     PFC     :=  mpiifort
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xAVX
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xAVX
++     FLIBS   := $(INCDIRS) -xAVX
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xAVX
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX
++        FLIBS   := $(INCDIRS) -xAVX
++     endif
++  endif
++  ifeq ($(MACHINENAME),rostam)
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xAVX
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xAVX
++     FLIBS   := $(INCDIRS) -xAVX
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xAVX
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX
++        FLIBS   := $(INCDIRS) -xAVX
+      endif
+   endif
+-  ifeq ($(MACHINENAME),queenbee) 
+-     FFLAGS1 := $(INCDIRS) -O3 -FI -assume byterecl -132 -xSSE4.2 -assume buffered_io
+-     CFLAGS  := $(INCDIRS) -O3 -DLINUX -xSSE4.2 
+-     FLIBS   := $(INCDIRS) -xSSE4.2 
++  ifeq ($(MACHINENAME),ls6)
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX
++     FLIBS   := $(INCDIRS)
+      ifeq ($(DEBUG),trace)
+-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xSSE4.2 -assume buffered_io
+-        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xSSE4.2 
+-        FLIBS   := $(INCDIRS) -xSSE4.2 
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX
++        FLIBS   := $(INCDIRS)
+      endif
+-  ifeq ($(MACHINENAME),supermic) 
+-     FFLAGS1 := $(INCDIRS) -O3 -FI -assume byterecl -132 -xAVX -assume buffered_io
+-     CFLAGS  := $(INCDIRS) -O3 -DLINUX -xAVX
++  endif
++  ifeq ($(MACHINENAME),mike)
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xAVX
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xAVX
+      FLIBS   := $(INCDIRS) -xAVX
+      ifeq ($(DEBUG),trace)
+-        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xAVX -assume buffered_io
+-        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX 
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xAVX
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX  -xAVX
+         FLIBS   := $(INCDIRS) -xAVX
+      endif
+   endif
++  ifeq ($(MACHINENAME),stampede3)
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xSAPPHIRERAPIDS
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xSAPPHIRERAPIDS -Wno-implicit-function-declaration
++     FLIBS   := $(INCDIRS) -axCORE-AVX512,COMMON-AVX512
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xSAPPHIRERAPIDS -check bounds -check pointers -heap-arrays
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xSAPPHIRERAPIDS -Wimplicit-function-declaration
++        FLIBS   := $(INCDIRS) -axCORE-AVX512,COMMON-AVX512
++     endif
++  endif
++  ifeq ($(MACHINENAME),carpenter)
++    # Baseline that runs on BOTH carpenter-serial (EPYC 7713 / znver3)
++    # and carpenter compute (EPYC 9654 / znver4)
++    FFLAGS1 := $(INCDIRS) -O2 -assume byterecl -132 -march=znver3
++    CFLAGS  := $(INCDIRS) -O2 -DLINUX -march=znver3 -Wno-implicit-function-declaration
++    FLIBS   := $(INCDIRS)
++    ifeq ($(DEBUG),trace)
++      FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -march=znver3
++      CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -march=znver3 -Wimplicit-function-declaration
++      FLIBS   := $(INCDIRS)
++    endif
++  endif
++  ifeq ($(MACHINENAME),mike-erdc)
++    FFLAGS1 := $(INCDIRS) -O2 -assume byterecl -132 -march=haswell
++    CFLAGS  := $(INCDIRS) -O2 -DLINUX -march=haswell -Wno-implicit-function-declaration
++    FLIBS   := $(INCDIRS)
++    ifeq ($(DEBUG),trace)
++      FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -march=haswell
++      CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -march=haswell -Wimplicit-function-declaration
++      FLIBS   := $(INCDIRS)
++    endif
++  endif
++  ifeq ($(MACHINENAME),debian)
++     FFLAGS1 := $(INCDIRS) -O2 -FI -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX2 -axCORE-AVX512 -Wno-implicit-function-declaration
++     FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++     ifeq ($(DEBUG),trace)
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -FI -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512 -Wimplicit-function-declaration
++        FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++     endif
++  endif
++  # METIS fix for icx
++  ifneq (,$(filter intel-oneapi,$(compiler)))
++    CFLAGS += -Wno-error=implicit-function-declaration
+   endif
+   #
+   #@jasonfleming Added to fix bus error on hatteras@renci
+@@ -302,67 +425,72 @@ ifeq ($(compiler),intel)
+      DPRE          := $(DPRE) -DADCSWAN
+   endif
+   IMODS         :=  -I
+-  CC            := icc
++  #CC            := icc  # get from start of this section
+   CCBE		:= $(CC)
+   CLIBS         :=
+   MSGLIBS       :=
+   ifeq ($(NETCDF),enable)
+-     ifeq ($(MACHINENAME),hatteras)
+-        NETCDFHOME  :=/usr/share/Modules/software/CentOS-7/netcdf-Fortran/4.4.0_intel-18.0.0
+-        FLIBS       :=$(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+-        FFLAGS1     :=$(FFLAGS1) -I$(NETCDFHOME)/include
+-        FFLAGS2     :=$(FFLAGS1)
+-        FFLAGS3     :=$(FFLAGS1)
++     FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      # jgf20150417 queenbee requires that the analyst load the netcdf and
+      # netcdf_fortran modules prior to compiling or executing ADCIRC
+      ifeq ($(MACHINENAME),queenbee)
+-        FLIBS       := $(FLIBS) -L/usr/local/packages/netcdf/4.2.1.1/INTEL-140-MVAPICH2-2.0/lib -lnetcdff -lnetcdf
+-        NETCDFHOME    :=/usr/local/packages/netcdf/4.2.1.1/INTEL-140-MVAPICH2-2.0
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
++     ifeq ($(MACHINENAME),queenbeeC)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
++     ifeq ($(MACHINENAME),queenbeeD)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),supermic)
+-        FLIBS      := $(FLIBS) -L /usr/local/packages/netcdf_fortran/4.2/INTEL-140-MVAPICH2-2.0/lib -lnetcdff -L/usr/local/packages/netcdf/4.2.1.1/INTEL-140-MVAPICH2-2.0/lib -lnetcdf -lnetcdf -liomp5 -lpthread
+-        NETCDFHOME :=/usr/local/packages/netcdf/4.2.1.1/INTEL-140-MVAPICH2-2.0/include
+-        FFLAGS1    :=$(FFLAGS1) -I/usr/local/packages/hdf5/1.8.12/INTEL-140-MVAPICH2-2.0/include
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
++     ifeq ($(MACHINENAME),rostam)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),stampede)
+-        NETCDFHOME :=/opt/apps/intel17/netcdf/4.3.3.1/x86_64
+         FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),stampede2)
+-        NETCDFHOME :=/opt/apps/intel17/netcdf/4.3.3.1/x86_64
+         FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+-        ifeq ($(USER),jgflemin)
+-           NETCDFHOME :=/work/00976/jgflemin/stampede2/local
+-           FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+-        endif
++     endif
++     ifeq ($(MACHINENAME),stampede3)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
++     ifeq ($(MACHINENAME),carpenter)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
++     ifeq ($(MACHINENAME),mike-erdc)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      ifeq ($(MACHINENAME),frontera)
+-        # specify NETCDFHOME on the command line or as an environment var
+         FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      # @jasonfleming: Added support for lonestar5 at tacc.utexas.edu;
+      # load the following module: netcdf/4.3.3.1
+      ifeq ($(MACHINENAME),lonestar5)
+-        #NETCDFHOME :=/opt/apps/intel18/netcdf/4.3.3.1/x86_64
+-        # @jasonfleming: Updated support for lonestar5
+-        NETCDFHOME :=/opt/apps/intel18/netcdf/4.6.2/x86_64
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
++     ifeq ($(MACHINENAME),ls6)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
++     ifeq ($(MACHINENAME),mike)
++        FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
++     endif
++     ifeq ($(MACHINENAME),debian)
+         FLIBS      := $(FLIBS) -L$(NETCDFHOME)/lib -lnetcdff -lnetcdf
+      endif
+      # jgf20150817: Adding support for spirit.afrl.hpc.mil;
+      # load the following modules: netcdf-fortran/intel/4.4.2
+      # and hdf5/intel/1.8.12 and hdf5-mpi/intel/sgimpt/1.8.12
+-     ifeq ($(MACHINENAME),spirit) 
++     ifeq ($(MACHINENAME),spirit)
+         NETCDFHOME :=/app/wpostool/COST/netcdf-fortran-4.4.2/intel
+         FLIBS      := $(FLIBS) -L/app/wpostool/COST/netcdf-c-4.3.1.1/intel/lib -L$(NETCDFHOME)/lib -L/app/wpostool/COST/hdf5-mpi/1.8.12/intel/sgimpt/lib -lnetcdff -lnetcdf
+      endif
+      # jgf20150420 mike requires that the analyst add netcdf to the softenv
+-     # with the following on the command line 
++     # with the following on the command line
+      # soft add +netcdf-4.1.3-Intel-13.0.0
+-     ifeq ($(MACHINENAME),mike)
+-        FLIBS       := $(FLIBS) -L/usr/local/packages/netcdf/4.1.3/Intel-13.0.0/lib -lnetcdff -lnetcdf
+-        NETCDFHOME    :=/usr/local/packages/netcdf/4.1.3/Intel-13.0.0
+-     endif
+      ifeq ($(MACHINENAME),killdevil)
+         HDF5HOME       :=/nas02/apps/hdf5-1.8.5/lib
+         NETCDFHOME     :=/nas02/apps/netcdf-4.1.1
+@@ -384,7 +512,7 @@ ifeq ($(compiler),intel-ND)
+   PPFC            :=  ifort
+   FC            :=  ifort
+   PFC           :=  mpif90
+-  FFLAGS1       :=  $(INCDIRS) -w -O3 -assume byterecl -132 -i-dynamic -assume buffered_io
++  FFLAGS1       :=  $(INCDIRS) -w -O2 -assume byterecl -132 -i-dynamic
+   ifeq ($(DEBUG),full)
+      FFLAGS1       :=  $(INCDIRS) -g -O0 -traceback -debug -check all -i-dynamic -FI -assume byterecl -132 -DALL_TRACE -DFULL_STACK -DFLUSH_MESSAGES
+   endif
+@@ -399,15 +527,15 @@ ifeq ($(compiler),intel-ND)
+   IMODS         :=  -I
+   CC            := icc
+   CCBE          := $(CC)
+-  CFLAGS        := $(INCDIRS) -O3 -m64 -mcmodel=medium -DLINUX
++  CFLAGS        := $(INCDIRS) -O2 -m64 -mcmodel=medium -DLINUX
+   FLIBS          :=
+   ifeq ($(DEBUG),full)
+      CFLAGS        := $(INCDIRS) -g -O0 -march=k8 -m64 -mcmodel=medium -DLINUX
+   endif
+   ifeq ($(NETCDF),enable)
+      HDF5HOME=/afs/crc.nd.edu/x86_64_linux/hdf/hdf5-1.8.6-linux-x86_64-static/lib
+-     FLIBS      := $(FLIBS) -lnetcdff -L$(HDF5HOME) 
+-  endif   
++     FLIBS      := $(FLIBS) -lnetcdff -L$(HDF5HOME)
++  endif
+   CLIBS         :=
+   MSGLIBS       :=
+   $(warning (INFO) Corresponding machine found in cmplrflags.mk.)
+@@ -428,7 +556,7 @@ ifeq ($(compiler),intel-sgi)
+   PFC           :=  mpif90
+   CC            :=  icc -O2 -no-ipo
+   CCBE          :=  icc -O2 -no-ipo
+-  FFLAGS1       :=  $(INCDIRS) -fixed -extend-source 132 -O2 -finline-limit=1000 -real-size 64 -no-ipo -assume buffered_io
++  FFLAGS1       :=  $(INCDIRS) -fixed -extend-source 132 -O2 -finline-limit=1000 -real-size 64 -no-ipo
+ #  FFLAGS1      :=  $(INCDIRS) -Mextend -g -O0 -traceback
+   FFLAGS2       :=  $(FFLAGS1)
+   FFLAGS3       :=  $(FFLAGS1) -assume buffered_stdout
+@@ -473,8 +601,7 @@ ifeq ($(compiler),cray_xt3)
+   FFLAGS2	:=  $(FFLAGS1)
+   FFLAGS3	:=  $(FFLAGS1) -r8 -Mr8 -Mr8intrinsics
+   DA  	        :=  -DREAL8 -DLINUX -DCSCA
+-  DP  	        :=  -DREAL8 -DLINUX -DCMPI -DHAVE_MPI_MOD -DCSCA -DDEBUG_WARN_ELEV
+-#  DP  	        :=  -DREAL8 -DLINUX -DCMPI -DHAVE_MPI_MOD -DCSCA
++  DP  	        :=  -DREAL8 -DLINUX -DCMPI -DHAVE_MPI_MOD -DCSCA
+   DPRE	        :=  -DREAL8 -DLINUX
+   CFLAGS	:=  -c89 $(INCDIRS) -DLINUX
+   IMODS		:=  -module
+@@ -504,7 +631,7 @@ ifeq ($(compiler),cray_xt4)
+   PFC	        :=  ftn
+   CC		:=  pgcc
+   CCBE		:=  cc
+-  FFLAGS1	:=  $(INCDIRS) -Mextend -Minform,inform -O2 -fastsse 
++  FFLAGS1	:=  $(INCDIRS) -Mextend -Minform,inform -O2 -fastsse
+   ifeq ($(DEBUG),full)
+      FFLAGS1	:=  $(INCDIRS) -Mextend -g -O0 -traceback -Mbounds -Mchkfpstk -Mchkptr -Mchkstk -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK
+   endif
+@@ -584,7 +711,7 @@ ifeq ($(compiler),xtintel)
+   PFC           :=  ftn
+   CC            :=  cc -O2 -no-ipo
+   CCBE          :=  cc -O2 -no-ipo
+-  FFLAGS1       :=  $(INCDIRS) -fixed -extend-source 132 -O2 -default64 -finline-limit=1000 -real-size 64 -no-ipo -assume buffered_io
++  FFLAGS1       :=  $(INCDIRS) -fixed -extend-source 132 -O2 -default64 -finline-limit=1000 -real-size 64 -no-ipo
+ #  FFLAGS1      :=  $(INCDIRS) -Mextend -g -O0 -traceback
+   FFLAGS2       :=  $(FFLAGS1)
+   FFLAGS3       :=  $(FFLAGS1) -assume buffered_stdout
+@@ -716,8 +843,8 @@ ifeq ($(compiler),diamond)
+   PPFC          :=  ifort
+   FC            :=  ifort
+   PFC           :=  ifort
+-#  FFLAGS1       :=  $(INCDIRS) -O3 -xT -132
+-  FFLAGS1       := -O3 -132 -xSSSE3
++#  FFLAGS1       :=  $(INCDIRS) -O2 -xT -132
++  FFLAGS1       := -O2 -132 -xSSSE3
+   ifeq ($(DEBUG),full)
+      FFLAGS1	:=  $(INCDIRS) -g -O0 -debug -fpe0 -132 -traceback -check all -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK
+   endif
+@@ -732,8 +859,8 @@ ifeq ($(compiler),diamond)
+   IMODS         :=  -I
+   CC            := icc
+   CCBE          := $(CC)
+-#  CFLAGS        := $(INCDIRS) -O3 -xT
+-  CFLAGS        := $(INCDIRS) -O3 -xSSSE3
++#  CFLAGS        := $(INCDIRS) -O2 -xT
++  CFLAGS        := $(INCDIRS) -O2 -xSSSE3
+   ifeq ($(DEBUG),full)
+      CFLAGS        := $(INCDIRS) -g -O0
+   endif
+@@ -784,7 +911,7 @@ ifeq ($(compiler),garnet)
+      CFLAGS	:=  $(INCDIRS) -DLINUX -g -O0
+   endif
+   IMODS		:=  -module
+-  FLIBS         := 
++  FLIBS         :=
+ # jgf20110728: on Garnet, NETCDFHOME=/opt/cray/netcdf/4.1.1.0/netcdf-pgi
+ # jgf20110815: on Garnet, HDF5HOME=/opt/cray/hdf5/default/hdf5-pgi
+ # jgf20130815: on Garnet, load module cray-netcdf, with the path to the
+@@ -809,7 +936,7 @@ ifeq ($(compiler),kraken)
+   PPFC          :=  ftn
+   FC            :=  ftn
+   PFC           :=  ftn
+-  FFLAGS1       :=  $(INCDIRS) -O3 -static  -132
++  FFLAGS1       :=  $(INCDIRS) -O2 -static  -132
+   FFLAGS2       :=  $(FFLAGS1)
+   FFLAGS3       :=  $(FFLAGS1)
+   DA            :=  -DREAL8 -DLINUX -DCSCA -DPOWELL
+@@ -845,7 +972,7 @@ ifeq ($(compiler),circleci)
+   IMODS 	:=  -I
+   CC		:= gcc
+   CCBE		:= $(CC)
+-  CFLAGS	:= $(INCDIRS) -O0 -g -mcmodel=medium -DLINUX -m64 
++  CFLAGS	:= $(INCDIRS) -O0 -g -mcmodel=medium -DLINUX -m64
+   CLIBS	:=
+   LIBS		:=
+   MSGLIBS	:=
+@@ -859,8 +986,7 @@ ifeq ($(compiler),circleci)
+      MULTIPLE := TRUE
+   endif
+ endif
+-#
+-endif
++
+ #$(MACHINE)
+ ########################################################################
+ # Compiler flags for Linux operating system on 32bit x86 CPU
+@@ -950,7 +1076,7 @@ ifeq ($(compiler),gnu)
+      FFLAGS1	:=  $(INCDIRS) -g -O0 -ffixed-line-length-132 -ftrace=full -fbounds-check -DNETCDF_TRACE -DFLUSH_MESSAGES -DFULL_STACK
+   endif
+   ifeq ($(DEBUG),valgrind)
+-     FFLAGS1	:=  $(INCDIRS) -g -O0 -ffixed-line-length-132 
++     FFLAGS1	:=  $(INCDIRS) -g -O0 -ffixed-line-length-132
+   endif
+   ifeq ($(SWAN),enable)
+      FFLAGS1    :=  $(FFLAGS1) -freal-loops
+@@ -988,69 +1114,6 @@ ifeq ($(compiler),gnu)
+   endif
+ endif
+ #
+-# gfortran
+-ifeq ($(compiler),gfortran)
+-  ifeq ($(MACHINENAME),jason-desktop)
+-     XDMFPATH    := /home/jason/projects/XDMF/Code/latestCode
+-     XDMFLIBPATH := /home/jason/projects/XDMF/Code/testLatest
+-  endif
+-  PPFC		:=  gfortran
+-  FC		:=  gfortran
+-  PFC		:=  mpif90
+-  FFLAGS1	:=  $(INCDIRS) -O2 -ffixed-line-length-none 
+-  ifeq ($(PROFILE),enable)
+-    FFLAGS1	:=  $(INCDIRS) -pg -O0 -fprofile-arcs -ftest-coverage -ffixed-line-length-none 
+-  endif
+-  ifeq ($(DEBUG),full)
+-    FFLAGS1	:=  $(INCDIRS) -g -O0 -ffixed-line-length-none -fbacktrace -fbounds-check -ffpe-trap=zero,invalid,overflow,denormal -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK -DDEBUG_HOLLAND -DDEBUG_WARN_ELEV
+-  endif
+-  ifeq ($(DEBUG),compiler-warnings)
+-    FFLAGS1	:=  $(INCDIRS) -g -O0 -Wall -Wextra -ffixed-line-length-none -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK
+-  endif
+-  ifeq ($(DEBUG),full-not-warnelev)
+-    FFLAGS1	:=  $(INCDIRS) -g -O0 -ffixed-line-length-none -fbacktrace -fbounds-check -ffpe-trap=zero,invalid,overflow,denormal -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK -DDEBUG_HOLLAND 
+-  endif
+-  ifeq ($(DEBUG),full-not-fpe)
+-    FFLAGS1	:=  $(INCDIRS) -g -O0 -ffixed-line-length-none -fbacktrace -fbounds-check -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK -DDEBUG_HOLLAND
+-  endif
+-  ifeq ($(DEBUG),trace)
+-    FFLAGS1	:=  $(INCDIRS) -g -O0 -ffixed-line-length-none -fbacktrace -DALL_TRACE -DFLUSH_MESSAGES -DFULL_STACK
+-  endif
+-  ifneq ($(MACHINENAME),jason-desktop)
+-     FFLAGS1 := $(FFLAGS1) -fno-underscoring
+-  endif
+-  FFLAGS2	:=  $(FFLAGS1)
+-  FFLAGS3	:=  $(FFLAGS1)
+-  DA		:=  -DREAL8 -DLINUX -DCSCA
+-  DP		:=  -DREAL8 -DLINUX -DCSCA -DCMPI
+-  DPRE		:=  -DREAL8 -DLINUX
+-  ifeq ($(SWAN),enable)
+-     DPRE               :=  -DREAL8 -DLINUX -DADCSWAN
+-  endif
+-  FLIBS         := 
+-  ifeq ($(NETCDF),enable)
+-     ifeq ($(MACHINENAME),jason-desktop)
+-        NETCDFHOME := /usr
+-     endif
+-     FLIBS      := $(FLIBS) -lnetcdff 
+-  endif
+-  IMODS 	:=  -I
+-  CC		:= gcc
+-  CCBE		:= $(CC)
+-  CFLAGS	:= $(INCDIRS) -O2 -DLINUX
+-  ifeq ($(DEBUG),full)
+-     CFLAGS     := $(INCDIRS) -g -O0 -DLINUX
+-  endif
+-  CLIBS	:=
+-  MSGLIBS	:=
+-  $(warning (INFO) Corresponding machine found in cmplrflags.mk.)
+-  ifneq ($(FOUND),TRUE)
+-     FOUND := TRUE
+-  else
+-     MULTIPLE := TRUE
+-  endif
+-endif
+-
+ endif
+ 
+ ########################################################################
+@@ -1095,7 +1158,7 @@ ifeq ($(arch),altix)
+   PPFC            := ifort
+   FC              := ifort
+   PFC             := ifort
+-  FFLAGS1	  := $(INCDIRS) -O3 -tpp2
++  FFLAGS1	  := $(INCDIRS) -O2 -tpp2
+   FFLAGS2	  := $(FFLAGS1)
+   FFLAGS3	  := $(FFLAGS1)
+   DA	          :=  -DREAL8 -DCSCA
+@@ -1168,7 +1231,7 @@ ifeq ($(IBM),p5)
+   FFLAGS0       := $(INCDIRS) -w -qfixed=132 -qarch=auto -qcache=auto
+   FFLAGS1       := $(FFLAGS0) -O2
+   FFLAGS2       := $(FFLAGS0) -qhot -qstrict
+-  FFLAGS3       := $(FFLAGS0) -O3 -qinitauto
++  FFLAGS3       := $(FFLAGS0) -O2 -qinitauto
+   DA            := -WF,"-DREAL8,-DIBM,-DCSCA"
+   DP            := -tF -WF,"-DREAL8,-DIBM,-DCSCA,-DCMPI"
+   DPRE          := -tF -WF,"-DREAL8,-DIBM"
+@@ -1488,9 +1551,9 @@ ifneq (,$(findstring powerpc-darwin,$(MACHINE)-$(OS)))
+   PPFC	        := f90
+   FC	        := f90
+   PFC	        := mpif77
+-  FFLAGS1	:=  $(INCDIRS) -w -O3 -m64 -cpu:g5 -f fixed -W132 -I . -DLINUX
+-  FFLAGS2	:=  $(INCDIRS) -w -O3 -m64 -cpu:g5 -N11 -f fixed -W132 -I .
+-  FFLAGS3	:=  $(INCDIRS) -w -O3 -m64 -cpu:g5 -N11 -f fixed -W132 -I .
++  FFLAGS1	:=  $(INCDIRS) -w -O2 -m64 -cpu:g5 -f fixed -W132 -I . -DLINUX
++  FFLAGS2	:=  $(INCDIRS) -w -O2 -m64 -cpu:g5 -N11 -f fixed -W132 -I .
++  FFLAGS3	:=  $(INCDIRS) -w -O2 -m64 -cpu:g5 -N11 -f fixed -W132 -I .
+   DA  	   	:=  -DREAL8 -DCSCA -DLINUX
+   DP  	   	:=  -DREAL8 -DCSCA -DCMPI -DLINUX
+   DPRE	   	:=  -DREAL8 -DLINUX
+@@ -1518,17 +1581,17 @@ ifneq (,$(findstring i386-darwin,$(MACHINE)-$(OS)))
+   PPFC	        := ifort
+   FC	        := ifort
+   PFC	        := mpif77
+-  FFLAGS1       :=  $(INCDIRS) -nowarn -O3    -fixed -132 -check all -traceback -DLINUX -DNETCDF_DEBUG -I .
+-# FFLAGS1	:=  $(INCDIRS) -nowarn -O3    -fixed -132 -DIBM -I .
+-  FFLAGS2	:=  $(INCDIRS) -nowarn -O3    -fixed -132 -I .
+-  FFLAGS3	:=  $(INCDIRS) -nowarn -O3    -fixed -132 -I .
++  FFLAGS1       :=  $(INCDIRS) -nowarn -O2    -fixed -132 -check all -traceback -DLINUX -DNETCDF_DEBUG -I .
++# FFLAGS1	:=  $(INCDIRS) -nowarn -O2    -fixed -132 -DIBM -I .
++  FFLAGS2	:=  $(INCDIRS) -nowarn -O2    -fixed -132 -I .
++  FFLAGS3	:=  $(INCDIRS) -nowarn -O2    -fixed -132 -I .
+   DA  	   	:=  -DREAL8 -DCSCA -DLINUX
+   DP  	   	:=  -DREAL8 -DCSCA -DLINUX -DCMPI -DNETCDF_DEBUG
+   DPRE	   	:=  -DREAL8 -DLINUX
+   IMODS  	:=  -I
+   CC            :=  gcc
+   CCBE          :=  $(CC)
+-  CFLAGS        :=  $(INCDIRS) -O3 -DLINUX
++  CFLAGS        :=  $(INCDIRS) -O2 -DLINUX
+   LDFLAGS	:=
+   FLIBS	        :=
+   MSGLIBS	:=

--- a/patches/ADCIRC/v53.05.live.0/02-prep-F.patch
+++ b/patches/ADCIRC/v53.05.live.0/02-prep-F.patch
@@ -1,0 +1,24 @@
+diff --git a/prep/prep.F b/prep/prep.F
+index c2a8ced..3cb30ee 100644
+--- a/prep/prep.F
++++ b/prep/prep.F
+@@ -791,7 +791,9 @@ CTGA 20180524: Adjusted code to better handle out-of-order attributes in the bod
+                IF (Mode.eq.0) SDNumND(iproc,k) = SDNumND(iproc,k)+1
+                IF (Mode.eq.1) THEN
+                   SDNode = IMAP_NOD_GL(2,NodeNum)
+-                  WRITE(sdu(iproc),1100) labels(NodeNum),(AttrData(j),j=1,NumCol(curAttrInd))!tgaf13mod
++                  ! jgf: write the fulldomain node number, it will be mapped
++                  ! to the subdomain node number at run time (patched by ASGS)
++                  WRITE(sdu(iproc),1100) NodeNum,(AttrData(j),j=1,NumCol(curAttrInd))!tgaf13mod
+                ENDIF
+             ELSE
+                DO m=1, ITOTPROC(NodeNum)
+@@ -803,7 +805,7 @@ CTGA 20180524: Adjusted code to better handle out-of-order attributes in the bod
+                         ENDIF
+                         IF (Mode.eq.1) THEN
+                            SDNode = IMAP_NOD_GL2(2*(m-1)+2,NodeNum)
+-                           WRITE(sdu(iproc),1100) labels(NodeNum),
++                           WRITE(sdu(iproc),1100) NodeNum,! patched by ASGS
+      &                          (AttrData(j),j=1,NumCol(curAttrInd))!tgaf13mod
+                         ENDIF
+                      ENDIF

--- a/patches/ADCIRC/v53.05.live.0/03-swan-platform-pl.patch
+++ b/patches/ADCIRC/v53.05.live.0/03-swan-platform-pl.patch
@@ -1,0 +1,691 @@
+diff --git a/swan/platform.pl b/swan/platform.pl
+index 92842ed..d4c6caa 100644
+--- a/swan/platform.pl
++++ b/swan/platform.pl
+@@ -39,6 +39,12 @@ if ($os =~ /IRIX64/i) {
+   print OUTFILE "  NCF_OBJS =\n";
+   print OUTFILE "endif\n";
+   print OUTFILE "O_DIR = ../work/odir4/\n";
++  print OUTFILE "BOU_OBJ = \$(O_DIR)boundaries.o\n";
++  print OUTFILE "ifneq (\"\$(wildcard \$(BOU_OBJ))\",\"\")\n";
++  print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)boundaries.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++  print OUTFILE "else\n";
++  print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++  print OUTFILE "endif\n";
+   print OUTFILE "OUT = -o \n";
+   print OUTFILE "EXTO = o\n";
+   print OUTFILE "MAKE = make\n";
+@@ -83,6 +89,12 @@ elsif ($os =~ /AIX/i) {
+   print OUTFILE "  NCF_OBJS =\n";
+   print OUTFILE "endif\n";
+   print OUTFILE "O_DIR = ../work/odir4/\n";
++  print OUTFILE "BOU_OBJ = \$(O_DIR)boundaries.o\n";
++  print OUTFILE "ifneq (\"\$(wildcard \$(BOU_OBJ))\",\"\")\n";
++  print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)boundaries.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++  print OUTFILE "else\n";
++  print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++  print OUTFILE "endif\n";
+   print OUTFILE "OUT = -o \n";
+   print OUTFILE "EXTO = o\n";
+   print OUTFILE "MAKE = make\n";
+@@ -115,6 +127,12 @@ elsif ($os =~ /OSF1/i) {
+   print OUTFILE "LIBS_OMP =\n";
+   print OUTFILE "LIBS_MPI = -lfmpi -lmpi -lelan\n";
+   print OUTFILE "O_DIR = ../work/odir4/\n";
++  print OUTFILE "BOU_OBJ = \$(O_DIR)boundaries.o\n";
++  print OUTFILE "ifneq (\"\$(wildcard \$(BOU_OBJ))\",\"\")\n";
++  print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)boundaries.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++  print OUTFILE "else\n";
++  print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++  print OUTFILE "endif\n";
+   print OUTFILE "OUT = -o \n";
+   print OUTFILE "EXTO = o\n";
+   print OUTFILE "MAKE = make\n";
+@@ -154,6 +172,12 @@ elsif ($os =~ /SunOS/i) {
+   print OUTFILE "  NCF_OBJS =\n";
+   print OUTFILE "endif\n";
+   print OUTFILE "O_DIR = ../work/odir4/\n";
++  print OUTFILE "BOU_OBJ = \$(O_DIR)boundaries.o\n";
++  print OUTFILE "ifneq (\"\$(wildcard \$(BOU_OBJ))\",\"\")\n";
++  print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)boundaries.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++  print OUTFILE "else\n";
++  print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++  print OUTFILE "endif\n";
+   print OUTFILE "OUT = -o \n";
+   print OUTFILE "EXTO = o\n";
+   print OUTFILE "MAKE = make\n";
+@@ -197,6 +221,12 @@ elsif ($os =~ /HP-UX/i) {
+   print OUTFILE "  NCF_OBJS =\n";
+   print OUTFILE "endif\n";
+   print OUTFILE "O_DIR =\n";
++  print OUTFILE "BOU_OBJ = \$(O_DIR)boundaries.o\n";
++  print OUTFILE "ifneq (\"\$(wildcard \$(BOU_OBJ))\",\"\")\n";
++  print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)boundaries.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++  print OUTFILE "else\n";
++  print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++  print OUTFILE "endif\n";
+   print OUTFILE "OUT = -o \n";
+   print OUTFILE "EXTO = o\n";
+   print OUTFILE "MAKE = make\n";
+@@ -211,12 +241,13 @@ elsif ($os =~ /Linux/i) {
+   my $compiler = getcmpl();
+   if ( $compiler eq "ifort" )
+   {
+-    print OUTFILE "##############################################################################\n";
+-    print OUTFILE "# IA32_Intel/x86-64_Intel:	Intel Pentium with Linux using Intel compiler 11.\n";
+-    print OUTFILE "##############################################################################\n";
++    print OUTFILE "################################################################################\n";
++    print OUTFILE "# IA32_Intel/x86-64_Intel:	Intel Core/Xeon with Linux using Intel compiler.\n";
++    print OUTFILE "################################################################################\n";
+     print OUTFILE "F90_SER = ifort\n";
+     print OUTFILE "F90_OMP = ifort\n";
+-    print OUTFILE "F90_MPI = mpif90\n";
++    print OUTFILE "# for older compiler versions, use mpif90\n";
++    print OUTFILE "F90_MPI = mpiifort\n";
+ #    if ($cpu =~ /i686/i) {
+ #      print OUTFILE "FLAGS_OPT = -O2 -xN -mp1\n";
+ #    }
+@@ -231,7 +262,7 @@ elsif ($os =~ /Linux/i) {
+     print OUTFILE "FLAGS90_MSC = \$(FLAGS_MSC)\n";
+     print OUTFILE "FLAGS_DYN = -fPIC\n";
+     print OUTFILE "FLAGS_SER =\n";
+-    print OUTFILE "FLAGS_OMP = -openmp\n";
++    print OUTFILE "FLAGS_OMP = -qopenmp\n";
+     print OUTFILE "FLAGS_MPI =\n";
+     print OUTFILE "NETCDFROOT =\n";
+     print OUTFILE "ifneq (\$(NETCDFROOT),)\n";
+@@ -252,6 +283,12 @@ elsif ($os =~ /Linux/i) {
+     print OUTFILE "  NCF_OBJS =\n";
+     print OUTFILE "endif\n";
+     print OUTFILE "O_DIR = ../work/odir4/\n";
++    print OUTFILE "BOU_OBJ = \$(O_DIR)boundaries.o\n";
++    print OUTFILE "ifneq (\"\$(wildcard \$(BOU_OBJ))\",\"\")\n";
++    print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)boundaries.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++    print OUTFILE "else\n";
++    print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++    print OUTFILE "endif\n";
+     print OUTFILE "OUT = -o \n";
+     print OUTFILE "EXTO = o\n";
+     print OUTFILE "MAKE = make\n";
+@@ -262,6 +299,59 @@ elsif ($os =~ /Linux/i) {
+     print OUTFILE "  swch = -unix -impi\n";
+     print OUTFILE "endif\n";
+   }
++  elsif ( $compiler eq "ifx" )
++  {
++    print OUTFILE <<EOF;
++################################################################################
++# Intel/x86-64_Intel:    Intel Core/Xeon with Linux using Intel OneAPI compiler.
++################################################################################
++F90_SER = ifx
++F90_OMP = ifx
++# for older compiler versions, use mpif90
++F90_MPI = mpiifx
++FLAGS_OPT = -O2
++FLAGS_MSC = -W0 -assume byterecl -traceback -diag-disable 8290 -diag-disable 8291 -diag-disable 8293
++FLAGS90_MSC = \$(FLAGS_MSC)
++FLAGS_DYN = -fPIC
++FLAGS_SER =
++FLAGS_OMP = -qopenmp
++FLAGS_MPI =
++NETCDFROOT =
++ifneq (\$(NETCDFROOT),)
++  INCS_SER = -I\$(NETCDFROOT)/include
++  INCS_OMP = -I\$(NETCDFROOT)/include
++  INCS_MPI = -I\$(NETCDFROOT)/include
++  LIBS_SER = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff
++  LIBS_OMP = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff
++  LIBS_MPI = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff
++  NCF_OBJS = nctablemd.o agioncmd.o swn_outnc.o
++else
++  INCS_SER =
++  INCS_OMP =
++  INCS_MPI =
++  LIBS_SER =
++  LIBS_OMP =
++  LIBS_MPI =
++  NCF_OBJS =
++endif
++O_DIR = ../work/odir4/
++BOU_OBJ = \$(O_DIR)boundaries.o
++ifneq (\"\$(wildcard \$(BOU_OBJ))\",\"\")
++  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)boundaries.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o
++else
++  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o
++endif
++OUT = -o 
++EXTO = o
++MAKE = make
++RM = rm -f
++ifneq (\$(NETCDFROOT),)
++  swch = -unix -impi -netcdf
++else
++  swch = -unix -impi
++endif
++EOF
++  }
+   elsif ( $compiler eq "ifc" )
+   {
+     print OUTFILE "##############################################################################\n";
+@@ -286,6 +376,7 @@ elsif ($os =~ /Linux/i) {
+     print OUTFILE "LIBS_OMP =\n";
+     print OUTFILE "LIBS_MPI =\n";
+     print OUTFILE "O_DIR = ../work/odir4/\n";
++    print OUTFILE "MSG_OBJS =\n";
+     print OUTFILE "OUT = -o \n";
+     print OUTFILE "EXTO = o\n";
+     print OUTFILE "MAKE = make\n";
+@@ -316,6 +407,7 @@ elsif ($os =~ /Linux/i) {
+     print OUTFILE "LIBS_OMP =\n";
+     print OUTFILE "LIBS_MPI =\n";
+     print OUTFILE "O_DIR = ../work/odir4/\n";
++    print OUTFILE "MSG_OBJS =\n";
+     print OUTFILE "OUT = -o \n";
+     print OUTFILE "EXTO = o\n";
+     print OUTFILE "MAKE = make\n";
+@@ -324,9 +416,9 @@ elsif ($os =~ /Linux/i) {
+   }
+   elsif ( $compiler eq "pgf90" )
+   {
+-    print OUTFILE "##############################################################################\n";
+-    print OUTFILE "# IA32_PGF:		Intel Pentium with Linux using Portland Group compiler\n";
+-    print OUTFILE "##############################################################################\n";
++    print OUTFILE "###########################################################################\n";
++    print OUTFILE "# x86-64_PGF:		Intel/AMD with Linux using Portland Group compiler.\n";
++    print OUTFILE "###########################################################################\n";
+     print OUTFILE "F90_SER = pgf90\n";
+     print OUTFILE "F90_OMP = pgf90\n";
+     print OUTFILE "F90_MPI = mpif90\n";
+@@ -356,6 +448,12 @@ elsif ($os =~ /Linux/i) {
+     print OUTFILE "  NCF_OBJS =\n";
+     print OUTFILE "endif\n";
+     print OUTFILE "O_DIR = ../work/odir4/\n";
++    print OUTFILE "BOU_OBJ = \$(O_DIR)boundaries.o\n";
++    print OUTFILE "ifneq (\"\$(wildcard \$(BOU_OBJ))\",\"\")\n";
++    print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)boundaries.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++    print OUTFILE "else\n";
++    print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++    print OUTFILE "endif\n";
+     print OUTFILE "OUT = -o \n";
+     print OUTFILE "EXTO = o\n";
+     print OUTFILE "MAKE = make\n";
+@@ -389,6 +487,7 @@ elsif ($os =~ /Linux/i) {
+     print OUTFILE "LIBS_OMP =\n";
+     print OUTFILE "LIBS_MPI =\n";
+     print OUTFILE "O_DIR =\n";
++    print OUTFILE "MSG_OBJS =\n";
+     print OUTFILE "OUT = -o \n";
+     print OUTFILE "EXTO = o\n";
+     print OUTFILE "MAKE = make\n";
+@@ -396,15 +495,72 @@ elsif ($os =~ /Linux/i) {
+     print OUTFILE "swch = -unix\n";
+   }
+   elsif ( $compiler eq "gfortran" )
++  {
++    my $ver = `gcc -dumpversion`;
++    print OUTFILE "###############################################################################\n";
++    print OUTFILE "# IA32_GNU:		Intel Core/Xeon with Linux using GNU compiler gfortran.\n";
++    print OUTFILE "###############################################################################\n";
++    print OUTFILE "F90_SER = gfortran\n";
++    print OUTFILE "F90_OMP = gfortran\n";
++    print OUTFILE "F90_MPI = mpif90\n";
++    print OUTFILE "FLAGS_OPT = -O\n";
++    if ($ver =~ /10/i) {
++      print OUTFILE "# gfortran 10 does not accept argument mismatches; see https://gcc.gnu.org/gcc-10/porting_to.html\n";
++      print OUTFILE "FLAGS_MSC = -w -fno-second-underscore -fallow-argument-mismatch\n";
++    }
++    else {
++      print OUTFILE "FLAGS_MSC = -w -fno-second-underscore\n";
++    }
++    print OUTFILE "FLAGS90_MSC = \$(FLAGS_MSC) -ffree-line-length-none\n";
++    print OUTFILE "FLAGS_DYN =\n";
++    print OUTFILE "FLAGS_SER =\n";
++    print OUTFILE "FLAGS_OMP = -fopenmp\n";
++    print OUTFILE "FLAGS_MPI =\n";
++    print OUTFILE "NETCDFROOT =\n";
++    print OUTFILE "ifneq (\$(NETCDFROOT),)\n";
++    print OUTFILE "  INCS_SER = -I\$(NETCDFROOT)/include\n";
++    print OUTFILE "  INCS_OMP = -I\$(NETCDFROOT)/include\n";
++    print OUTFILE "  INCS_MPI = -I\$(NETCDFROOT)/include\n";
++    print OUTFILE "  LIBS_SER = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff\n";
++    print OUTFILE "  LIBS_OMP = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff -static-libgcc\n";
++    print OUTFILE "  LIBS_MPI = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff\n";
++    print OUTFILE "  NCF_OBJS = nctablemd.o agioncmd.o swn_outnc.o\n";
++    print OUTFILE "else\n";
++    print OUTFILE "  INCS_SER =\n";
++    print OUTFILE "  INCS_OMP =\n";
++    print OUTFILE "  INCS_MPI =\n";
++    print OUTFILE "  LIBS_SER =\n";
++    print OUTFILE "  LIBS_OMP = -static-libgcc\n";
++    print OUTFILE "  LIBS_MPI =\n";
++    print OUTFILE "  NCF_OBJS =\n";
++    print OUTFILE "endif\n";
++    print OUTFILE "O_DIR = ../work/odir4/\n";
++    print OUTFILE "BOU_OBJ = \$(O_DIR)boundaries.o\n";
++    print OUTFILE "ifneq (\"\$(wildcard \$(BOU_OBJ))\",\"\")\n";
++    print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)boundaries.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++    print OUTFILE "else\n";
++    print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++    print OUTFILE "endif\n";
++    print OUTFILE "OUT = -o \n";
++    print OUTFILE "EXTO = o\n";
++    print OUTFILE "MAKE = make\n";
++    print OUTFILE "RM = rm -f\n";
++    print OUTFILE "ifneq (\$(NETCDFROOT),)\n";
++    print OUTFILE "  swch = -unix -netcdf\n";
++    print OUTFILE "else\n";
++    print OUTFILE "  swch = -unix\n";
++    print OUTFILE "endif\n";
++  }
++  elsif ( $compiler eq "gfortran10.1" )
+   {
+     print OUTFILE "##############################################################################\n";
+-    print OUTFILE "# IA32_GNU:		Intel Pentium with Linux using GNU compiler gfortran.\n";
++    print OUTFILE "# IA32_GNU:		Intel Pentium with Linux using GNU compiler gfortran >= 10.1.\n";
+     print OUTFILE "##############################################################################\n";
+     print OUTFILE "F90_SER = gfortran\n";
+     print OUTFILE "F90_OMP = gfortran\n";
+     print OUTFILE "F90_MPI = mpif90\n";
+     print OUTFILE "FLAGS_OPT = -O\n";
+-    print OUTFILE "FLAGS_MSC = -w -fno-second-underscore\n";
++    print OUTFILE "FLAGS_MSC = -w -fno-second-underscore -fallow-argument-mismatch\n";
+     print OUTFILE "FLAGS90_MSC = \$(FLAGS_MSC) -ffree-line-length-none\n";
+     print OUTFILE "FLAGS_DYN =\n";
+     print OUTFILE "FLAGS_SER =\n";
+@@ -442,7 +598,7 @@ elsif ($os =~ /Linux/i) {
+   elsif ( $compiler eq "g95" )
+   {
+     print OUTFILE "##############################################################################\n";
+-    print OUTFILE "# IA32_GNU:		Intel Pentium with Linux using GNU compiler g95.\n";
++    print OUTFILE "# IA32_GNU:		Intel Core/Xeon with Linux using GNU compiler g95.\n";
+     print OUTFILE "##############################################################################\n";
+     print OUTFILE "F90_SER = g95\n";
+     print OUTFILE "F90_OMP = NO_OPENMP_WITH_G95\n";
+@@ -473,6 +629,12 @@ elsif ($os =~ /Linux/i) {
+     print OUTFILE "  NCF_OBJS =\n";
+     print OUTFILE "endif\n";
+     print OUTFILE "O_DIR = ../work/odir4/\n";
++    print OUTFILE "BOU_OBJ = \$(O_DIR)boundaries.o\n";
++    print OUTFILE "ifneq (\"\$(wildcard \$(BOU_OBJ))\",\"\")\n";
++    print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)boundaries.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++    print OUTFILE "else\n";
++    print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++    print OUTFILE "endif\n";
+     print OUTFILE "OUT = -o \n";
+     print OUTFILE "EXTO = o\n";
+     print OUTFILE "MAKE = make\n";
+@@ -517,6 +679,12 @@ elsif ($os =~ /Linux/i) {
+     print OUTFILE "  NCF_OBJS =\n";
+     print OUTFILE "endif\n";
+     print OUTFILE "O_DIR = ../work/odir4/\n";
++    print OUTFILE "BOU_OBJ = \$(O_DIR)boundaries.o\n";
++    print OUTFILE "ifneq (\"\$(wildcard \$(BOU_OBJ))\",\"\")\n";
++    print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)boundaries.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++    print OUTFILE "else\n";
++    print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++    print OUTFILE "endif\n";
+     print OUTFILE "OUT = -o \n";
+     print OUTFILE "EXTO = o\n";
+     print OUTFILE "MAKE = make\n";
+@@ -534,51 +702,54 @@ elsif ($os =~ /Linux/i) {
+ }
+ elsif ($os =~ /WindowsNT/i || $os =~ /MSWin32/i || $os =~ /CYGWIN/i) {
+   my $compiler = getcmpl();
+-  if ( $compiler eq "ifort" )
++  if ( $compiler eq "ifort.exe" )
+   {
+-    print OUTFILE "##############################################################################\n";
+-    print OUTFILE "# IA32_Intel/EM64T_Intel:	Intel Pentium with MS Windows using Intel compiler 11.\n";
+-    print OUTFILE "##############################################################################\n";
++    print OUTFILE "#####################################################################################\n";
++    print OUTFILE "# IA32_Intel/EM64T_Intel:	Intel Core/Xeon with MS Windows using Intel compiler.\n";
++    print OUTFILE "#####################################################################################\n";
+     print OUTFILE "F90_SER = ifort\n";
+     print OUTFILE "F90_OMP = ifort\n";
+-    print OUTFILE "F90_MPI = ifort\n";
+-    print OUTFILE "FLAGS_OPT = /optimize:2\n";
++    print OUTFILE "F90_MPI = mpiifort\n";
++    print OUTFILE "FLAGS_OPT = /O2\n";
+ #    print OUTFILE "FLAGS_MSC = /assume:byterecl /traceback /nowarn /nologo /Qdiag-disable:remark\n";
+     print OUTFILE "FLAGS_MSC = /assume:byterecl /traceback /nowarn /nologo /Qdiag-disable:8290 /Qdiag-disable:8291 /Qdiag-disable:8293\n";
+     print OUTFILE "FLAGS90_MSC = \$(FLAGS_MSC)\n";
+     print OUTFILE "FLAGS_DYN =\n";
+     print OUTFILE "FLAGS_SER =\n";
+-    print OUTFILE "FLAGS_OMP = /Qopenmp /Qopenmp-link:static\n";
++    print OUTFILE "FLAGS_OMP = /Qopenmp\n";
+     print OUTFILE "FLAGS_MPI =\n";
+-    print OUTFILE "#NETCDFROOT = C:\\\PROGRA~2\\\lnetcdf\n";
+-    print OUTFILE "!IF DEFINED(NETCDFROOT)\n";
+-    print OUTFILE "INCS_SER = /include:\$(NETCDFROOT)\n";
+-    print OUTFILE "INCS_OMP = /include:\$(NETCDFROOT)\n";
+-    print OUTFILE "INCS_MPI = /include:\"C:\\\PROGRA~1\\\MPICH2\\\include\" /include:\$(NETCDFROOT)\n";
+-    print OUTFILE "LIBSC = /link /NODEFAULTLIB:MSVCRT.lib /NODEFAULTLIB:LIBC.lib\n";
+-    print OUTFILE "LIBS_SER = \$(NETCDFROOT)\\\lf90_netcdf.lib \$(NETCDFROOT)\\\lf77_netcdf.lib \$(NETCDFROOT)\\\lnetcdf.lib \$(LIBSC)\n";
+-    print OUTFILE "LIBS_OMP = \$(NETCDFROOT)\\\lf90_netcdf.lib \$(NETCDFROOT)\\\lf77_netcdf.lib \$(NETCDFROOT)\\\lnetcdf.lib \$(LIBSC)\n";
+-    print OUTFILE "LIBS_MPI = C:\\\PROGRA~1\\\MPICH2\\\llib\\\lfmpich2.lib \$(NETCDFROOT)\\\lf90_netcdf.lib \$(NETCDFROOT)\\\lf77_netcdf.lib \$(NETCDFROOT)\\\lnetcdf.lib \$(LIBSC)\n";
+-    print OUTFILE "NCF_OBJS = nctablemd.obj agioncmd.obj swn_outnc.obj\n";
+-    print OUTFILE "!ELSE\n";
++#    print OUTFILE "#NETCDFROOT = C:\\\PROGRA~2\\\lnetcdf\n";
++#    print OUTFILE "!IF DEFINED(NETCDFROOT)\n";
++#    print OUTFILE "INCS_SER = /include:\$(NETCDFROOT)\n";
++#    print OUTFILE "INCS_OMP = /include:\$(NETCDFROOT)\n";
++#    print OUTFILE "INCS_MPI = /include:\"C:\\\PROGRA~1\\\MPICH2\\\include\" /include:\$(NETCDFROOT)\n";
++#    print OUTFILE "LIBSC = /link /NODEFAULTLIB:MSVCRT.lib /NODEFAULTLIB:LIBC.lib\n";
++#    print OUTFILE "LIBS_SER = \$(NETCDFROOT)\\\lf90_netcdf.lib \$(NETCDFROOT)\\\lf77_netcdf.lib \$(NETCDFROOT)\\\lnetcdf.lib \$(LIBSC)\n";
++#    print OUTFILE "LIBS_OMP = \$(NETCDFROOT)\\\lf90_netcdf.lib \$(NETCDFROOT)\\\lf77_netcdf.lib \$(NETCDFROOT)\\\lnetcdf.lib \$(LIBSC)\n";
++#    print OUTFILE "LIBS_MPI = C:\\\PROGRA~1\\\MPICH2\\\llib\\\lfmpich2.lib \$(NETCDFROOT)\\\lf90_netcdf.lib \$(NETCDFROOT)\\\lf77_netcdf.lib \$(NETCDFROOT)\\\lnetcdf.lib \$(LIBSC)\n";
++#    print OUTFILE "NCF_OBJS = nctablemd.obj agioncmd.obj swn_outnc.obj\n";
++#    print OUTFILE "!ELSE\n";
+     print OUTFILE "INCS_SER =\n";
+     print OUTFILE "INCS_OMP =\n";
+-    print OUTFILE "INCS_MPI = /include:\"C:\\\PROGRA~1\\\MPICH2\\\include\"\n";
++#    print OUTFILE "INCS_MPI = /include:\"C:\\\PROGRA~1\\\MPICH2\\\include\"\n";
++    print OUTFILE "INCS_MPI =\n";
+     print OUTFILE "LIBS_SER =\n";
+     print OUTFILE "LIBS_OMP =\n";
+-    print OUTFILE "LIBS_MPI = C:\\\PROGRA~1\\\MPICH2\\\llib\\\lfmpich2.lib\n";
+-    print OUTFILE "NCF_OBJS =\n";
+-    print OUTFILE "!ENDIF\n";
++#    print OUTFILE "LIBS_MPI = C:\\\PROGRA~1\\\MPICH2\\\llib\\\lfmpich2.lib\n";
++    print OUTFILE "LIBS_MPI =\n";
++#    print OUTFILE "NCF_OBJS =\n";
++#    print OUTFILE "!ENDIF\n";
+     print OUTFILE "O_DIR =\n";
++    print OUTFILE "MSG_OBJS =\n";
+     print OUTFILE "OUT = /exe:\n";
+     print OUTFILE "EXTO = obj\n";
+     print OUTFILE "MAKE = nmake\n";
+     print OUTFILE "RM = del\n";
+-    print OUTFILE "!IF DEFINED(NETCDFROOT)\n";
+-    print OUTFILE "swch = -dos -impi -cvis -netcdf\n";
+-    print OUTFILE "!ELSE\n";
++#    print OUTFILE "!IF DEFINED(NETCDFROOT)\n";
++#    print OUTFILE "swch = -dos -impi -cvis -netcdf\n";
++#    print OUTFILE "!ELSE\n";
+     print OUTFILE "swch = -dos -impi -cvis\n";
+-    print OUTFILE "!ENDIF\n";
++#    print OUTFILE "!ENDIF\n";
+   }
+   elsif ( $compiler eq "f90" )
+   {
+@@ -614,6 +785,7 @@ elsif ($os =~ /WindowsNT/i || $os =~ /MSWin32/i || $os =~ /CYGWIN/i) {
+     print OUTFILE "NCF_OBJS =\n";
+     print OUTFILE "!ENDIF\n";
+     print OUTFILE "O_DIR =\n";
++    print OUTFILE "MSG_OBJS =\n";
+     print OUTFILE "OUT = /exe:\n";
+     print OUTFILE "EXTO = obj\n";
+     print OUTFILE "MAKE = nmake\n";
+@@ -630,47 +802,169 @@ elsif ($os =~ /WindowsNT/i || $os =~ /MSWin32/i || $os =~ /CYGWIN/i) {
+   }
+ }
+ elsif ($os =~ /Darwin/i) {
+-  print OUTFILE "##############################################################################\n";
+-  print OUTFILE "# MAC_IBM:		MAC OS X Apple with IBM Compiler.\n";
+-  print OUTFILE "##############################################################################\n";
+-  print OUTFILE "F90_SER = xlf90\n";
+-  print OUTFILE "F90_OMP =\n";
+-  print OUTFILE "F90_MPI =\n";
+-  print OUTFILE "FLAGS_OPT = -O3 -qstrict -qtune=auto -qcache=auto -qalign=4k\n";
+-  print OUTFILE "FLAGS_MSC = -w -qfixed\n";
+-  print OUTFILE "FLAGS90_MSC = -w -qfree=f90\n";
+-  print OUTFILE "FLAGS_DYN =\n";
+-  print OUTFILE "FLAGS_SER =\n";
+-  print OUTFILE "FLAGS_OMP =\n";
+-  print OUTFILE "FLAGS_MPI =\n";
+-  print OUTFILE "NETCDFROOT =\n";
+-  print OUTFILE "ifneq (\$(NETCDFROOT),)\n";
+-  print OUTFILE "  INCS_SER = -I\$(NETCDFROOT)/include\n";
+-  print OUTFILE "  INCS_OMP = -I\$(NETCDFROOT)/include\n";
+-  print OUTFILE "  INCS_MPI = -I\$(NETCDFROOT)/include\n";
+-  print OUTFILE "  LIBS_SER = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff\n";
+-  print OUTFILE "  LIBS_OMP = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff\n";
+-  print OUTFILE "  LIBS_MPI = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff\n";
+-  print OUTFILE "  NCF_OBJS = nctablemd.o agioncmd.o swn_outnc.o\n";
+-  print OUTFILE "else\n";
+-  print OUTFILE "  INCS_SER =\n";
+-  print OUTFILE "  INCS_OMP =\n";
+-  print OUTFILE "  INCS_MPI =\n";
+-  print OUTFILE "  LIBS_SER =\n";
+-  print OUTFILE "  LIBS_OMP =\n";
+-  print OUTFILE "  LIBS_MPI =\n";
+-  print OUTFILE "  NCF_OBJS =\n";
+-  print OUTFILE "endif\n";
+-  print OUTFILE "O_DIR =\n";
+-  print OUTFILE "OUT = -o \n";
+-  print OUTFILE "EXTO = o\n";
+-  print OUTFILE "MAKE = make\n";
+-  print OUTFILE "RM = rm -f\n";
+-  print OUTFILE "ifneq (\$(NETCDFROOT),)\n";
+-  print OUTFILE "  swch = -unix -netcdf\n";
+-  print OUTFILE "else\n";
+-  print OUTFILE "  swch = -unix\n";
+-  print OUTFILE "endif\n";
++  my $compiler = getcmpl();
++  if ( $compiler eq "gfortran" )
++  {
++    my $ver = `gcc -dumpversion`;
++    print OUTFILE "#########################################################\n";
++    print OUTFILE "# MAC_GNU:		macOS with GNU compiler gfortran.\n";
++    print OUTFILE "#########################################################\n";
++    print OUTFILE "F90_SER = gfortran\n";
++    print OUTFILE "F90_OMP = gfortran\n";
++    print OUTFILE "F90_MPI = mpif90\n";
++    print OUTFILE "FLAGS_OPT = -O\n";
++    if ($ver =~ /10/i) {
++      print OUTFILE "# gfortran 10 does not accept argument mismatches; see https://gcc.gnu.org/gcc-10/porting_to.html\n";
++      print OUTFILE "FLAGS_MSC = -w -fno-second-underscore -fallow-argument-mismatch\n";
++    }
++    else {
++      print OUTFILE "FLAGS_MSC = -w -fno-second-underscore\n";
++    }
++    print OUTFILE "FLAGS90_MSC = \$(FLAGS_MSC) -ffree-line-length-none\n";
++    print OUTFILE "FLAGS_DYN =\n";
++    print OUTFILE "FLAGS_SER =\n";
++    print OUTFILE "FLAGS_OMP = -fopenmp\n";
++    print OUTFILE "FLAGS_MPI =\n";
++    print OUTFILE "NETCDFROOT =\n";
++    print OUTFILE "ifneq (\$(NETCDFROOT),)\n";
++    print OUTFILE "  INCS_SER = -I\$(NETCDFROOT)/include\n";
++    print OUTFILE "  INCS_OMP = -I\$(NETCDFROOT)/include\n";
++    print OUTFILE "  INCS_MPI = -I\$(NETCDFROOT)/include\n";
++    print OUTFILE "  LIBS_SER = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff\n";
++    print OUTFILE "  LIBS_OMP = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff -static-libgcc\n";
++    print OUTFILE "  LIBS_MPI = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff\n";
++    print OUTFILE "  NCF_OBJS = nctablemd.o agioncmd.o swn_outnc.o\n";
++    print OUTFILE "else\n";
++    print OUTFILE "  INCS_SER =\n";
++    print OUTFILE "  INCS_OMP =\n";
++    print OUTFILE "  INCS_MPI =\n";
++    print OUTFILE "  LIBS_SER =\n";
++    print OUTFILE "  LIBS_OMP = -static-libgcc\n";
++    print OUTFILE "  LIBS_MPI =\n";
++    print OUTFILE "  NCF_OBJS =\n";
++    print OUTFILE "endif\n";
++    print OUTFILE "O_DIR = ../work/odir4/\n";
++    print OUTFILE "BOU_OBJ = \$(O_DIR)boundaries.o\n";
++    print OUTFILE "ifneq (\"\$(wildcard \$(BOU_OBJ))\",\"\")\n";
++    print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)boundaries.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++    print OUTFILE "else\n";
++    print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++    print OUTFILE "endif\n";
++    print OUTFILE "OUT = -o \n";
++    print OUTFILE "EXTO = o\n";
++    print OUTFILE "MAKE = make\n";
++    print OUTFILE "RM = rm -f\n";
++    print OUTFILE "ifneq (\$(NETCDFROOT),)\n";
++    print OUTFILE "  swch = -unix -netcdf\n";
++    print OUTFILE "else\n";
++    print OUTFILE "  swch = -unix\n";
++    print OUTFILE "endif\n";
++  }
++  elsif ( $compiler eq "ifort" )
++  {
++    print OUTFILE "##################################################\n";
++    print OUTFILE "# MAC_Intel:		macOS with Intel compiler.\n";
++    print OUTFILE "##################################################\n";
++    print OUTFILE "F90_SER = ifort\n";
++    print OUTFILE "F90_OMP = ifort\n";
++    print OUTFILE "# for older compiler versions, use mpif90\n";
++    print OUTFILE "F90_MPI = mpiifort\n";
++    print OUTFILE "FLAGS_OPT = -O2\n";
++    print OUTFILE "FLAGS_MSC = -W0 -assume byterecl -traceback -diag-disable 8290 -diag-disable 8291 -diag-disable 8293\n";
++    print OUTFILE "FLAGS90_MSC = \$(FLAGS_MSC)\n";
++    print OUTFILE "FLAGS_DYN = -fPIC\n";
++    print OUTFILE "FLAGS_SER =\n";
++    print OUTFILE "FLAGS_OMP = -qopenmp\n";
++    print OUTFILE "FLAGS_MPI =\n";
++    print OUTFILE "NETCDFROOT =\n";
++    print OUTFILE "ifneq (\$(NETCDFROOT),)\n";
++    print OUTFILE "  INCS_SER = -I\$(NETCDFROOT)/include\n";
++    print OUTFILE "  INCS_OMP = -I\$(NETCDFROOT)/include\n";
++    print OUTFILE "  INCS_MPI = -I\$(NETCDFROOT)/include\n";
++    print OUTFILE "  LIBS_SER = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff\n";
++    print OUTFILE "  LIBS_OMP = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff\n";
++    print OUTFILE "  LIBS_MPI = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff\n";
++    print OUTFILE "  NCF_OBJS = nctablemd.o agioncmd.o swn_outnc.o\n";
++    print OUTFILE "else\n";
++    print OUTFILE "  INCS_SER =\n";
++    print OUTFILE "  INCS_OMP =\n";
++    print OUTFILE "  INCS_MPI =\n";
++    print OUTFILE "  LIBS_SER =\n";
++    print OUTFILE "  LIBS_OMP =\n";
++    print OUTFILE "  LIBS_MPI =\n";
++    print OUTFILE "  NCF_OBJS =\n";
++    print OUTFILE "endif\n";
++    print OUTFILE "O_DIR = ../work/odir4/\n";
++    print OUTFILE "BOU_OBJ = \$(O_DIR)boundaries.o\n";
++    print OUTFILE "ifneq (\"\$(wildcard \$(BOU_OBJ))\",\"\")\n";
++    print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)boundaries.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++    print OUTFILE "else\n";
++    print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++    print OUTFILE "endif\n";
++    print OUTFILE "OUT = -o \n";
++    print OUTFILE "EXTO = o\n";
++    print OUTFILE "MAKE = make\n";
++    print OUTFILE "RM = rm -f\n";
++    print OUTFILE "ifneq (\$(NETCDFROOT),)\n";
++    print OUTFILE "  swch = -unix -impi -netcdf\n";
++    print OUTFILE "else\n";
++    print OUTFILE "  swch = -unix -impi\n";
++    print OUTFILE "endif\n";
++  }
++  elsif ( $compiler eq "xlf90" )
++  {
++    print OUTFILE "##############################################################################\n";
++    print OUTFILE "# MAC_IBM:		Mac OS X with IBM Compiler.\n";
++    print OUTFILE "##############################################################################\n";
++    print OUTFILE "F90_SER = xlf90\n";
++    print OUTFILE "F90_OMP =\n";
++    print OUTFILE "F90_MPI =\n";
++    print OUTFILE "FLAGS_OPT = -O3 -qstrict -qtune=auto -qcache=auto -qalign=4k\n";
++    print OUTFILE "FLAGS_MSC = -w -qfixed\n";
++    print OUTFILE "FLAGS90_MSC = -w -qfree=f90\n";
++    print OUTFILE "FLAGS_DYN =\n";
++    print OUTFILE "FLAGS_SER =\n";
++    print OUTFILE "FLAGS_OMP =\n";
++    print OUTFILE "FLAGS_MPI =\n";
++    print OUTFILE "NETCDFROOT =\n";
++    print OUTFILE "ifneq (\$(NETCDFROOT),)\n";
++    print OUTFILE "  INCS_SER = -I\$(NETCDFROOT)/include\n";
++    print OUTFILE "  INCS_OMP = -I\$(NETCDFROOT)/include\n";
++    print OUTFILE "  INCS_MPI = -I\$(NETCDFROOT)/include\n";
++    print OUTFILE "  LIBS_SER = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff\n";
++    print OUTFILE "  LIBS_OMP = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff\n";
++    print OUTFILE "  LIBS_MPI = -L\$(NETCDFROOT)/lib -lnetcdf -lnetcdff\n";
++    print OUTFILE "  NCF_OBJS = nctablemd.o agioncmd.o swn_outnc.o\n";
++    print OUTFILE "else\n";
++    print OUTFILE "  INCS_SER =\n";
++    print OUTFILE "  INCS_OMP =\n";
++    print OUTFILE "  INCS_MPI =\n";
++    print OUTFILE "  LIBS_SER =\n";
++    print OUTFILE "  LIBS_OMP =\n";
++    print OUTFILE "  LIBS_MPI =\n";
++    print OUTFILE "  NCF_OBJS =\n";
++    print OUTFILE "endif\n";
++    print OUTFILE "O_DIR =\n";
++    print OUTFILE "BOU_OBJ = \$(O_DIR)boundaries.o\n";
++    print OUTFILE "ifneq (\"\$(wildcard \$(BOU_OBJ))\",\"\")\n";
++    print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)boundaries.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++    print OUTFILE "else\n";
++    print OUTFILE "  MSG_OBJS = \$(O_DIR)mkdir.o \$(O_DIR)sizes.o \$(O_DIR)global.o \$(O_DIR)global_3dvs.o \$(O_DIR)version.o \$(O_DIR)messenger.o\n";
++    print OUTFILE "endif\n";
++    print OUTFILE "OUT = -o \n";
++    print OUTFILE "EXTO = o\n";
++    print OUTFILE "MAKE = make\n";
++    print OUTFILE "RM = rm -f\n";
++    print OUTFILE "ifneq (\$(NETCDFROOT),)\n";
++    print OUTFILE "  swch = -unix -netcdf\n";
++    print OUTFILE "else\n";
++    print OUTFILE "  swch = -unix\n";
++    print OUTFILE "endif\n";
++  }
++  else
++  {
++    die "Current Fortran compiler '$compiler' not supported.... \n";
++  }
+ }
+ else
+ {
+@@ -684,16 +978,55 @@ close(OUTFILE);
+ sub getcmpl {
+ 
+    my $compiler = $ENV{'FC'};
++   my $cc       = $ENV{'CC'};
++
++   my $wants_oneapi =
++         (defined $cc       && $cc eq 'icx')
++      || (defined $compiler && $compiler eq 'ifx');
++
++   if ($wants_oneapi) {
++      return 'ifx'   if `command -v mpiifx >/dev/null 2>&1 && echo yes`;
++      return 'ifort' if `command -v mpiifort >/dev/null 2>&1 && echo yes`;
++      die "Neither mpiifx nor mpiifort was found in PATH\n";
++   }
+ 
+-   unless ( $compiler ) {
+-      foreach ('ifort','f90','ifc','efc','pgf90','xlf90', 'lf95','gfortran','g95') {
+-         $compiler = $_;
+-         my $path  = `which $compiler`;
+-         last if $path;
++   if (defined $compiler && $compiler ne '') {
++      return 'ifort' if $compiler eq 'ifort' || $compiler eq 'mpiifort';
++
++      if ($compiler eq 'gfortran') {
++         my $version_str = `gfortran -dumpversion 2>/dev/null`;
++         chomp($version_str);
++         if ($version_str =~ /^(\d+)(?:\.(\d+))?/) {
++            my ($major, $minor) = ($1, $2 // 0);
++            return "gfortran10.1"
++               if ($major > 10 || ($major == 10 && $minor >= 1));
++         }
++      }
++
++      return $compiler;
++   }
++
++   return 'ifx'   if `command -v mpiifx >/dev/null 2>&1 && echo yes`;
++   return 'ifort' if `command -v mpiifort >/dev/null 2>&1 && echo yes`;
++
++   foreach my $try ('ifort','f90','ifc','efc','pgf90','xlf90','lf95','gfortran','g95') {
++      my $path = `which $try 2>/dev/null`;
++      next unless $path;
++
++      if ($try eq 'gfortran') {
++         my $version_str = `gfortran -dumpversion 2>/dev/null`;
++         chomp($version_str);
++         if ($version_str =~ /^(\d+)(?:\.(\d+))?/) {
++            my ($major, $minor) = ($1, $2 // 0);
++            return "gfortran10.1"
++               if ($major > 10 || ($major == 10 && $minor >= 1));
++         }
+       }
++
++      return $try;
+    }
+ 
+-   return $compiler;
++   return undef;
+ }
+ 
+ # =============================================================================

--- a/patches/ADCIRC/v53.05.live.0/about.txt
+++ b/patches/ADCIRC/v53.05.live.0/about.txt
@@ -1,0 +1,1 @@
+Long-term maintained release of ADCIRC v53.05 by ADCIRC Live

--- a/patches/ADCIRC/v53.05.live.0/info.sh
+++ b/patches/ADCIRC/v53.05.live.0/info.sh
@@ -1,0 +1,5 @@
+export ADCIRC_SRC_TYPE=git
+export ADCIRC_GIT_URL=https://github.com/stormsurgelive
+export ADCIRC_GIT_REPO=adcirc
+export ADCIRC_GIT_BRANCH=v53.05.live.0
+export SWANDIR=swan

--- a/patches/ADCIRC/v53release/about.txt
+++ b/patches/ADCIRC/v53release/about.txt
@@ -1,1 +1,1 @@
-(default) latest upstream v53.05 + adcprep "--prep13" fix
+upstream v53.05 + adcprep "--prep13" fix

--- a/patches/ADCIRC/v53release/info.sh
+++ b/patches/ADCIRC/v53release/info.sh
@@ -1,5 +1,5 @@
 export ADCIRC_SRC_TYPE=git
-export ADCIRC_GIT_URL=https://github.com/stormsurgelive
+export ADCIRC_GIT_URL=https://github.com/adcirc
 export ADCIRC_GIT_REPO=adcirc
-export ADCIRC_GIT_BRANCH=v53release
+export ADCIRC_GIT_BRANCH=v53.05
 export SWANDIR=swan


### PR DESCRIPTION
Issue 1705: listing v53release as what it really is, keeping existing v53release for now which
is identical except that it pulls from the upstream ADCIRC repo

Resolves #1705.