### PR TITLE
Fixed CFLAGS for debian broken with Intel OneAPI 2026.0

### DIFF
--- a/patches/ADCIRC/v56.0.4.live.0/01-cmplrflags-mk.patch
+++ b/patches/ADCIRC/v56.0.4.live.0/01-cmplrflags-mk.patch
@@ -1,5 +1,5 @@
 diff --git a/work/cmplrflags.mk b/work/cmplrflags.mk
-index ac418b2..eea2656 100644
+index ac418b2..24c0cbc 100644
 --- a/work/cmplrflags.mk
 +++ b/work/cmplrflags.mk
 @@ -1,152 +1,1648 @@
@@ -460,13 +460,13 @@ index ac418b2..eea2656 100644
 +    endif
 +  endif
 +  ifeq ($(filter debian debian+%,$(MACHINENAME)), $(MACHINENAME))
-+     FFLAGS1 := $(INCDIRS) -O2 -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
-+     CFLAGS  := $(INCDIRS) -O2 -DLINUX -xCORE-AVX2 -axCORE-AVX512 -Wno-implicit-function-declaration
-+     FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++     FFLAGS1 := $(INCDIRS) -O2 -assume byterecl -132
++     CFLAGS  := $(INCDIRS) -O2 -DLINUX -Wno-implicit-function-declaration -Wno-incompatible-pointer-types
++     FLIBS   := $(INCDIRS)
 +     ifeq ($(DEBUG),trace)
-+        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132 -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
-+        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512 -Wimplicit-function-declaration
-+        FLIBS   := $(INCDIRS) -xCORE-AVX2 -axCORE-AVX512,COMMON-AVX512
++        FFLAGS1 := $(INCDIRS) -g -O0 -traceback -assume byterecl -132
++        CFLAGS  := $(INCDIRS) -g -O0 -traceback -DLINUX -Wimplicit-function-declaration -Wno-incompatible-pointer-types
++        FLIBS   := $(INCDIRS)
 +     endif
 +  endif
 +  ifeq ($(MACHINENAME),rhel)


### PR DESCRIPTION
Issue 1717: The latest Intel OneAPI icx requires a flag to support incompatible pointers present in the METIS source code. Also removed Intel architecture specific flags on "debian" Linux environments that are also AMD.

Resolves #1717.