### PR TITLE
Validate local assets path during init

### DIFF
--- a/init-asgs.sh
+++ b/init-asgs.sh
@@ -70,7 +70,13 @@ while getopts "Abc:L:mp:x:" optname; do
       c) # update DEFAULT_COMPILER for use with -b, really
 	 FORCE_DEFAULT_COMPILER=${OPTARG}
 	 ;;
-      L|p) export ASGS_LOCAL_DIR=$(readlink -f "${OPTARG}") # get full path
+      L|p)
+         # Fail early so a typo in -L/-p does not silently fall back to repo assets.
+         if [[ ! -d "${OPTARG}" ]]; then
+           echo "${W} Local assets directory specified with -L/-p does not exist: ${OPTARG}" >&2
+           exit 1
+         fi
+         export ASGS_LOCAL_DIR=$(readlink -f "${OPTARG}") # get full path
          ;;
       x) # add extra arbitrary options to asgs-brew.pl command
          if [ -z "${EXTRA_ASGSBREW_OPTS}" ]; then


### PR DESCRIPTION
Fixes #1646

## Summary
- Validate the raw `-L/-p` local assets path before canonicalizing it with `readlink -f`.
- Exit early with a warning if the directory does not exist.
- Prevent typos in local assets paths from silently falling back to repo assets.

## Testing
- `./init-asgs.sh -L /bad/path` exits immediately with the expected warning.
- `./init-asgs.sh` starts normally without local assets.
- `./init-asgs.sh -L /ddnA/work/enikidis/asgs-local-assets` starts normally and shows `Local Site Dir`.
- `bash -n init-asgs.sh`