### PR TITLE
Adding trailing slash for directory listing.

### DIFF
--- a/bin/get_nam_status.pl
+++ b/bin/get_nam_status.pl
@@ -62,7 +62,7 @@ GetOptions(
 
     sub http_dir {
         my $dir = shift;
-        my $url         = sprintf( qq{https://nomads.ncep.noaa.gov%s}, $dir );
+        my $url         = sprintf( qq{https://nomads.ncep.noaa.gov%s/}, $dir );
         my $res         = $ua->get($url);
         my $raw_listing = $res->{content};
         my @dirs        = ( $raw_listing =~ m/href="(nam\.\d{8}|\d\d)\/"/g );


### PR DESCRIPTION
Issue 1738: Upstream changes to the NOAA webserver configuration is refusing to list the file index without an explicit trailing slash. This commit adds that to the NAM dir listing request.

Resolves #1738.